### PR TITLE
ci: Prepare release pipeline for immutable releases + tighten attestation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,12 +42,41 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # semantic-release creates the release as a DRAFT (draftRelease in .releaserc) with no
+      # assets. Immutable releases lock on *publish* and reject post-publish asset uploads, so
+      # we must upload while still a draft, then publish: draft -> attach -> publish.
+      - name: Upload patch bundle to draft release
+        if: steps.release.outputs.new_release_published == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.release.outputs.new_release_git_tag }}
+        run: |
+          set -euo pipefail
+          # The main bundle only — exclude the -sources/-javadoc .mpp variants.
+          mpp=$(ls patches/build/libs/patches-*.mpp | grep -Ev '(sources|javadoc)')
+          echo "Uploading: $mpp"
+          gh release upload "$TAG" $mpp --clobber
+
       - name: Attest
         if: steps.release.outputs.new_release_published == 'true'
         uses: actions/attest-build-provenance@v4
         with:
           subject-name: 'Morphe Patches ${{ steps.release.outputs.new_release_git_tag }}'
-          subject-path: patches/build/libs/patches-*.mpp
+          subject-path: |
+            patches/build/libs/patches-*.mpp
+            !patches/build/libs/patches-*-sources.mpp
+            !patches/build/libs/patches-*-javadoc.mpp
+
+      # Publishing the draft is what makes the release immutable (once the repo/org setting is
+      # enabled) and triggers GitHub's automatic release attestation.
+      - name: Publish release
+        if: steps.release.outputs.new_release_published == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.release.outputs.new_release_git_tag }}
+        # No --latest: preserve semantic-release's prerelease flag (dev = prerelease) and let
+        # GitHub's default "latest" logic apply, so dev pre-releases aren't marked latest.
+        run: gh release edit "$TAG" --draft=false
 
       # Always verify compilation when semantic-release did not publish a release.
       # This covers non-main/dev branches, chore commits, docs commits, etc.

--- a/.releaserc
+++ b/.releaserc
@@ -66,11 +66,7 @@
     [
       "@semantic-release/github",
       {
-        "assets": [
-          {
-            "path": "patches/build/libs/patches-!(*sources*|*javadoc*).mpp?(.asc)"
-          }
-        ],
+        "draftRelease": true,
         "successComment": false
       }
     ],


### PR DESCRIPTION
Prepares the release pipeline for **GitHub immutable releases** and tightens the existing build-provenance attestation.

## Why
Immutable releases (GA Oct 2025) lock a release on **publish** and reject asset uploads afterward, requiring a **draft → attach assets → publish** order. But the pinned `@semantic-release/github` **v12.0.9** publishes the release and *then* uploads the `.mpp` (no draft→publish support). Enabling immutability naively would break the `.mpp` upload on every release.

## Changes
- **`.releaserc`** — `@semantic-release/github` now creates a **draft** with no assets (`draftRelease: true`, assets array removed).
- **`release.yml`** — after semantic-release: upload the `.mpp` to the draft via `gh release upload`, then `gh release edit --draft=false` to publish. Publishing is what triggers immutability + GitHub's automatic release attestation. No `--latest`, so `dev` pre-releases keep their prerelease flag.
- **Attestation** — `subject-path` now excludes the `-sources`/`-javadoc` `.mpp` variants, attesting only the released bundle.

## Rollout (gated — do NOT enable the setting yet)
1. Merge this → next `dev` pre-release exercises the draft→publish flow. **Immutability stays off**, so a published draft works either way — this validates the restructure in isolation.
2. Verify the pre-release: release is published, the `.mpp` is attached, `gh attestation verify` passes.
3. **Only then** enable the immutable-releases repo/org setting (Settings → repository, or `gh api`). The following release will be immutable with assets attached.

Rollback = revert this commit (restores the direct publish + plugin asset upload).

## Not verifiable locally
`release.yml` + `.releaserc` only exercise the release path on `dev`/`main`; on a branch/PR the workflow runs the compile-check path. So the draft→publish flow is first proven on the initial `dev` pre-release after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
