### PR TITLE
feat: Add experimental Hide Home modules patch

### DIFF
--- a/extensions/extension/src/main/java/app/andrewliang/extension/HomeModules.java
+++ b/extensions/extension/src/main/java/app/andrewliang/extension/HomeModules.java
@@ -1,0 +1,38 @@
+package app.andrewliang.extension;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Helper for hiding LINE Home tab modules.
+ *
+ * LINE's Home tab is a server-driven list of typed modules (m52.a0, each with a stable
+ * getType() string). The patch iterates that list in injected smali and drops modules whose
+ * type this helper flags — the extension only makes the String decision (it cannot reference
+ * the obfuscated LINE module classes).
+ *
+ * EXPERIMENTAL blocklist for the test-build loop: hides the strong candidate types for the
+ * bottom-of-Home ad, 即時夯話題 (real-time hot topics), and recommended stickers. Narrow this
+ * to the confirmed types once device testing maps each section to its type.
+ */
+public final class HomeModules {
+
+    private HomeModules() {}
+
+    private static final Set<String> HIDDEN = new HashSet<>();
+
+    static {
+        // Ad modules (bottom-of-Home ad candidates).
+        HIDDEN.add("HomePerformanceAd");
+        HIDDEN.add("AdModel");
+        // Content-recommendation candidates (即時夯話題 / recommended stickers).
+        HIDDEN.add("HomeContentsRecommendation");
+        HIDDEN.add("HomeFeedMatomeCarousel");
+        HIDDEN.add("HomeFeedMatomeSingle");
+    }
+
+    /** @return true if a Home module of this type should be hidden. */
+    public static boolean shouldHide(String type) {
+        return type != null && HIDDEN.contains(type);
+    }
+}

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidehomemodules/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidehomemodules/Fingerprints.kt
@@ -1,0 +1,22 @@
+package app.andrewliang.patches.line.hidehomemodules
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.methodCall
+
+/**
+ * `i52.c.e(f0, c): i0` — builds the Home UI state `m52.i0`, whose module list (`List<m52.z>`,
+ * each `z.e` a typed `m52.a0` module) is assembled into a register and passed as the 3rd
+ * constructor arg. We inject a filter right before that `m52.i0.<init>` call.
+ *
+ * `i52.c` is obfuscated (version-brittle); anchored on the return type `Lm52/i0;`, the
+ * `(f0, c)` params, and the `m52.i0.<init>` call the injection is placed before.
+ */
+internal object HomeStateBuilderFingerprint : Fingerprint(
+    definingClass = "Li52/c;",
+    name = "e",
+    returnType = "Lm52/i0;",
+    parameters = listOf("Lm52/f0;", "Lm52/c;"),
+    filters = listOf(
+        methodCall(definingClass = "Lm52/i0;", name = "<init>"),
+    ),
+)

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidehomemodules/HideHomeModulesPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidehomemodules/HideHomeModulesPatch.kt
@@ -1,0 +1,57 @@
+package app.andrewliang.patches.line.hidehomemodules
+
+import app.andrewliang.patches.shared.Constants.COMPATIBILITY_LINE
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.bytecodePatch
+
+@Suppress("unused")
+val hideHomeModulesPatch = bytecodePatch(
+    name = "Hide Home modules",
+    description = "Hides selected Home-tab modules (bottom ad, recommended content sections). " +
+        "EXPERIMENTAL — blocklist being tuned.",
+    default = false, // opt-in until the type blocklist is confirmed on device.
+) {
+    compatibleWith(COMPATIBILITY_LINE)
+
+    extendWith("extensions/extension.mpe")
+
+    // In i52.c.e, the Home module list (List<m52.z>) is assembled in v6 and passed as the 3rd
+    // arg to m52.i0.<init>. Inject a filter right before that constructor call: rebuild v6
+    // keeping only modules whose z.e.getType() is NOT flagged by the extension. v6 (the list)
+    // and v3..v12 (the ctor args) stay live; v13/v14/v15 are free scratch under .locals 18.
+    // Iteration is done in smali (it can reference the obfuscated m52.z/m52.a0 descriptors);
+    // the extension only makes the String blocklist decision.
+    //
+    // Registers passed to iget-object (22c) / invoke-* (35c) must be v0-v15 (4-bit operands),
+    // so the per-element scratch uses v0 — safe because nothing between here and the i0.<init>
+    // reads v0. v13/v14/v15 are only used as invoke/iget operands (all <= v15).
+    execute {
+        val ctorIndex = HomeStateBuilderFingerprint.instructionMatches.first().index
+        HomeStateBuilderFingerprint.method.addInstructions(
+            ctorIndex,
+            """
+                new-instance v13, Ljava/util/ArrayList;
+                invoke-direct {v13}, Ljava/util/ArrayList;-><init>()V
+                invoke-interface {v6}, Ljava/util/List;->iterator()Ljava/util/Iterator;
+                move-result-object v14
+                :loop
+                invoke-interface {v14}, Ljava/util/Iterator;->hasNext()Z
+                move-result v0
+                if-eqz v0, :done
+                invoke-interface {v14}, Ljava/util/Iterator;->next()Ljava/lang/Object;
+                move-result-object v15
+                check-cast v15, Lm52/z;
+                iget-object v0, v15, Lm52/z;->e:Lm52/a0;
+                invoke-interface {v0}, Lm52/a0;->getType()Ljava/lang/String;
+                move-result-object v0
+                invoke-static {v0}, Lapp/andrewliang/extension/HomeModules;->shouldHide(Ljava/lang/String;)Z
+                move-result v0
+                if-nez v0, :loop
+                invoke-virtual {v13, v15}, Ljava/util/ArrayList;->add(Ljava/lang/Object;)Z
+                goto :loop
+                :done
+                move-object v6, v13
+            """,
+        )
+    }
+}


### PR DESCRIPTION
**Experimental** — adds a "Hide Home modules" patch to hide the bottom-of-Home ad and recommended content sections (即時夯話題, recommended stickers). Opt-in (`default = false`) until the type blocklist is confirmed on device.

## How it works
LINE's Home tab is a **server-driven list of typed modules** (`m52.a0`, each with a stable `getType()` string; that's why `即時夯話題` isn't in local string resources). The modules are wrapped in `m52.z` and assembled into the UI state `m52.i0`.

This patch injects a filter at the assembler `i52.c.e`, right before the `m52.i0.<init>` call: it rebuilds the module list keeping only modules whose `z.e.getType()` isn't blocklisted. Iteration is done in smali (it can reference the obfuscated `m52.z`/`m52.a0` descriptors); the `HomeModules` extension makes only the String decision.

## Why it's experimental
Server-driven module titles can't be mapped to their `getType()` strings by static analysis. The blocklist is a **candidate set** to narrow via device testing:
`HomePerformanceAd`, `AdModel`, `HomeContentsRecommendation`, `HomeFeedMatomeCarousel`, `HomeFeedMatomeSingle`.

**Test loop:** build with `--exclusive -e "Hide Home modules"`, install, and report which of {bottom ad, 即時夯話題, recommended stickers} disappear + whether any wanted Home content vanished. Then I'll lock the blocklist and split into final packaging (ad types → Hide ad views; content types → a "Declutter Home" patch).

## Verification
- Builds; applies to LINE 26.11.0 (fingerprint resolves); disassembly confirms the full filter loop (`z.e → getType → shouldHide → conditional add`) lands before `i0.<init>`, extension bundled.
- Caught + fixed a register bug: an earlier revision used `v16` in `iget`/`invoke` (4-bit-operand instructions allow only v0–v15), which silently dropped the filter core → fixed to `v0` and re-verified in bytecode.

## Notes
- Branched off `dev`; independent of the device-fix work in PR #7. `i52.c` is obfuscated → version-pinned to 26.11.0.
- `default = false` so merging to `dev` won't auto-apply an unconfirmed blocklist in the pre-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
