### PR TITLE
feat: Add LINE hide-line-today-tab patch

### DIFF
--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidelinetodaytab/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidelinetodaytab/Fingerprints.kt
@@ -1,0 +1,21 @@
+package app.andrewliang.patches.line.hidelinetodaytab
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.fieldAccess
+
+private const val MAIN_TAB = "Ljp/naver/line/android/activity/main/a;"
+
+/**
+ * Matches `wy7.b.a()` — the main bottom-nav tab-list builder — via its access to the
+ * non-obfuscated LINE TODAY tab constants. LINE TODAY is represented by two variants:
+ * `NEWS` (the main news tab → `NewsMainTabFragment`) and `NEWS_ROW` (the news-row variant →
+ * `NewsRowFragment`). Both are added in `a()`; matching both yields the two `sget-object`
+ * indices whose `sget`+`ArrayList.add` pairs are removed.
+ */
+internal object LineTodayTabListFingerprint : Fingerprint(
+    returnType = "Ljava/util/List;",
+    filters = listOf(
+        fieldAccess(definingClass = MAIN_TAB, name = "NEWS"),
+        fieldAccess(definingClass = MAIN_TAB, name = "NEWS_ROW"),
+    ),
+)

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidelinetodaytab/HideLineTodayTabPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidelinetodaytab/HideLineTodayTabPatch.kt
@@ -1,0 +1,28 @@
+package app.andrewliang.patches.line.hidelinetodaytab
+
+import app.andrewliang.patches.shared.Constants.COMPATIBILITY_LINE
+import app.morphe.patcher.extensions.InstructionExtensions.removeInstructions
+import app.morphe.patcher.patch.bytecodePatch
+
+@Suppress("unused")
+val hideLineTodayTabPatch = bytecodePatch(
+    name = "Hide LINE TODAY tab",
+    description = "Removes the LINE TODAY (News) tab from the main bottom navigation, " +
+        "in both the news-tab and news-row layouts.",
+    default = true,
+) {
+    compatibleWith(COMPATIBILITY_LINE)
+
+    // Remove the NEWS and NEWS_ROW `sget-object` + following `ArrayList.add` pairs from the
+    // tab-list builder. instructionMatches[0] = NEWS (earlier), [1] = NEWS_ROW (later);
+    // remove the higher index first so the earlier one stays valid.
+    execute {
+        val matches = LineTodayTabListFingerprint.instructionMatches
+        val newsIndex = matches[0].index
+        val newsRowIndex = matches[1].index
+        LineTodayTabListFingerprint.method.apply {
+            removeInstructions(newsRowIndex, 2)
+            removeInstructions(newsIndex, 2)
+        }
+    }
+}


### PR DESCRIPTION
Adds the **Hide LINE TODAY tab** patch. This was authored earlier but got stranded: its commit landed on `fix/line-patch-device-issues` *after* PR #7 had already merged, so it never reached `dev`. This re-lands it cleanly (cherry-pick of the original signed commit).

## What it does
Removes the LINE TODAY (News) tab from the main bottom navigation. LINE TODAY = the `NEWS` main-tab enum family — `NEWS` (→ `NewsMainTabFragment`) and `NEWS_ROW` (→ `NewsRowFragment`). In the tab-list builder `wy7.b.a()`, both constants' `sget-object` + `ArrayList.add` pairs are removed. Same mechanism as the Wallet/VOOM tab patches; `default = true`.

## Verification
Built against current `dev` (with the device fixes merged), applies to LINE 26.11.0 via the Morphe CLI, and disassembly confirms NEWS/NEWS_ROW are gone from `wy7.b.a()`. Coexists with the Wallet/VOOM tab-hiders (all edit the same method, verified earlier). Device-confirmed working in an earlier round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
