### PR TITLE
fix: Hide Home modules crashed on open (VerifyError)

### DIFF
--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidehomemodules/HideHomeModulesPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidehomemodules/HideHomeModulesPatch.kt
@@ -3,6 +3,15 @@ package app.andrewliang.patches.line.hidehomemodules
 import app.andrewliang.patches.shared.Constants.COMPATIBILITY_LINE
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.builder.MutableMethodImplementation
+import com.android.tools.smali.dexlib2.immutable.ImmutableMethod
+import com.android.tools.smali.dexlib2.immutable.ImmutableMethodParameter
+
+private const val I52_C = "Li52/c;"
+private const val FILTER_NAME = "filterHomeModules"
+private const val FILTER_DESC = "(Ljava/util/List;)Ljava/util/List;"
 
 @Suppress("unused")
 val hideHomeModulesPatch = bytecodePatch(
@@ -15,42 +24,67 @@ val hideHomeModulesPatch = bytecodePatch(
 
     extendWith("extensions/extension.mpe")
 
-    // In i52.c.e, the Home module list (List<m52.z>) is assembled in v6 and passed as the 3rd
-    // arg to m52.i0.<init>. Inject a filter right before that constructor call: rebuild v6
-    // keeping only modules whose z.e.getType() is NOT flagged by the extension. v6 (the list)
-    // and v3..v12 (the ctor args) stay live; v13/v14/v15 are free scratch under .locals 18.
-    // Iteration is done in smali (it can reference the obfuscated m52.z/m52.a0 descriptors);
-    // the extension only makes the String blocklist decision.
+    // The Home module list (List<m52.z>, each z.e a typed m52.a0 module) is assembled in
+    // i52.c.e and passed as arg3 (register v6) to m52.i0.<init>. We drop modules whose
+    // z.e.getType() is blocklisted.
     //
-    // Registers passed to iget-object (22c) / invoke-* (35c) must be v0-v15 (4-bit operands),
-    // so the per-element scratch uses v0 — safe because nothing between here and the i0.<init>
-    // reads v0. v13/v14/v15 are only used as invoke/iget operands (all <= v15).
+    // The filtering loop lives in its OWN new method (i52.c.filterHomeModules) rather than
+    // being injected inline. Injecting a backward-branching loop into the existing
+    // 126-instruction e() corrupted its branch layout -> runtime VerifyError "target dex pc
+    // not at instruction start". A freshly built method's branches assemble cleanly, and the
+    // call injected into e() is branchless (invoke + move-result), so it can't misalign e().
     execute {
+        // 1. Add the static filter helper method to i52.c.
+        val cls = mutableClassDefBy(I52_C)
+        val filter = MutableMethod(
+            ImmutableMethod(
+                I52_C,
+                FILTER_NAME,
+                listOf(ImmutableMethodParameter("Ljava/util/List;", null, null)),
+                "Ljava/util/List;",
+                AccessFlags.PUBLIC.value or AccessFlags.STATIC.value,
+                null,
+                null,
+                MutableMethodImplementation(6),
+            ),
+        )
+        cls.methods.add(filter)
+        // p0 = input List. v0 = result ArrayList, v1 = iterator, v2 = element, v3 = type/bool.
+        filter.addInstructions(
+            0,
+            """
+                new-instance v0, Ljava/util/ArrayList;
+                invoke-direct {v0}, Ljava/util/ArrayList;-><init>()V
+                invoke-interface {p0}, Ljava/util/List;->iterator()Ljava/util/Iterator;
+                move-result-object v1
+                :loop
+                invoke-interface {v1}, Ljava/util/Iterator;->hasNext()Z
+                move-result v2
+                if-eqz v2, :done
+                invoke-interface {v1}, Ljava/util/Iterator;->next()Ljava/lang/Object;
+                move-result-object v2
+                check-cast v2, Lm52/z;
+                iget-object v3, v2, Lm52/z;->e:Lm52/a0;
+                invoke-interface {v3}, Lm52/a0;->getType()Ljava/lang/String;
+                move-result-object v3
+                invoke-static {v3}, Lapp/andrewliang/extension/HomeModules;->shouldHide(Ljava/lang/String;)Z
+                move-result v3
+                if-nez v3, :loop
+                invoke-virtual {v0, v2}, Ljava/util/ArrayList;->add(Ljava/lang/Object;)Z
+                goto :loop
+                :done
+                return-object v0
+            """,
+        )
+
+        // 2. In e(), replace the module list (v6) with the filtered list right before the
+        //    m52.i0.<init> call. Branchless: just invoke + move-result.
         val ctorIndex = HomeStateBuilderFingerprint.instructionMatches.first().index
         HomeStateBuilderFingerprint.method.addInstructions(
             ctorIndex,
             """
-                new-instance v13, Ljava/util/ArrayList;
-                invoke-direct {v13}, Ljava/util/ArrayList;-><init>()V
-                invoke-interface {v6}, Ljava/util/List;->iterator()Ljava/util/Iterator;
-                move-result-object v14
-                :loop
-                invoke-interface {v14}, Ljava/util/Iterator;->hasNext()Z
-                move-result v0
-                if-eqz v0, :done
-                invoke-interface {v14}, Ljava/util/Iterator;->next()Ljava/lang/Object;
-                move-result-object v15
-                check-cast v15, Lm52/z;
-                iget-object v0, v15, Lm52/z;->e:Lm52/a0;
-                invoke-interface {v0}, Lm52/a0;->getType()Ljava/lang/String;
-                move-result-object v0
-                invoke-static {v0}, Lapp/andrewliang/extension/HomeModules;->shouldHide(Ljava/lang/String;)Z
-                move-result v0
-                if-nez v0, :loop
-                invoke-virtual {v13, v15}, Ljava/util/ArrayList;->add(Ljava/lang/Object;)Z
-                goto :loop
-                :done
-                move-object v6, v13
+                invoke-static {v6}, $I52_C->$FILTER_NAME$FILTER_DESC
+                move-result-object v6
             """,
         )
     }


### PR DESCRIPTION
Fixes the crash-on-open you hit testing the Hide Home modules patch.

## Root cause
Runtime `VerifyError: ...i52.c.e...: target dex pc 0x25 is not at instruction start`. The experimental patch injected a backward-branching filter loop inline into the existing 126-instruction `i52.c.e`, which corrupted that method's branch layout when reassembled.

## Fix
Extract the loop into its own new method `i52.c.filterHomeModules(List): List` (added via `mutableClassDefBy` + `MutableMethod`), and inject only a branchless `invoke-static` + `move-result` into `e()`. A freshly built method assembles its branches cleanly, and the call site in `e()` has no branches to misalign.

## Verification
- Builds; applies to LINE 26.11.0; disassembly confirms `filterHomeModules` exists with the loop (getType + shouldHide), `e()` has only the branchless call (no inline loop), extension bundled.
- Still `default = false`; the type blocklist mapping (即時夯話題 / stickers / bottom ad) still needs the device test loop — this PR just makes it not crash so that testing can proceed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)