### PR TITLE
chore: DIAGNOSTIC logging for Hide Home modules (revert after capture)

### DIFF
--- a/extensions/extension/src/main/java/app/andrewliang/extension/HomeModules.java
+++ b/extensions/extension/src/main/java/app/andrewliang/extension/HomeModules.java
@@ -1,5 +1,7 @@
 package app.andrewliang.extension;
 
+import android.util.Log;
+
 import java.util.HashSet;
 import java.util.Set;
 
@@ -11,28 +13,42 @@ import java.util.Set;
  * type this helper flags — the extension only makes the String decision (it cannot reference
  * the obfuscated LINE module classes).
  *
- * EXPERIMENTAL blocklist for the test-build loop: hides the strong candidate types for the
- * bottom-of-Home ad, 即時夯話題 (real-time hot topics), and recommended stickers. Narrow this
- * to the confirmed types once device testing maps each section to its type.
+ * DIAGNOSTIC BUILD: every module type encountered is logged to logcat under tag
+ * "MorpheHomeModules", so the real type strings of the visible Home sections can be captured
+ * on device (the type -> visible-section mapping can't be determined statically). Also logs a
+ * one-time marker when the filter runs, so we can tell "filter ran but nothing matched" apart
+ * from "filter never ran (wrong injection point)". Capture with:
+ *   adb logcat -s MorpheHomeModules
+ * Once the real types are known, set the blocklist to them and remove the logging.
  */
 public final class HomeModules {
 
     private HomeModules() {}
 
+    private static final String TAG = "MorpheHomeModules";
+
     private static final Set<String> HIDDEN = new HashSet<>();
 
     static {
-        // Ad modules (bottom-of-Home ad candidates).
+        // Candidate blocklist (unconfirmed) — bottom ad + recommended content.
         HIDDEN.add("HomePerformanceAd");
         HIDDEN.add("AdModel");
-        // Content-recommendation candidates (即時夯話題 / recommended stickers).
         HIDDEN.add("HomeContentsRecommendation");
         HIDDEN.add("HomeFeedMatomeCarousel");
         HIDDEN.add("HomeFeedMatomeSingle");
     }
 
+    /** DIAGNOSTIC: called once at filter entry so "ran but empty/unmatched" is distinguishable
+     *  from "never ran". Returns the list unchanged. */
+    public static java.util.List onEnter(java.util.List modules) {
+        Log.i(TAG, "filterHomeModules ENTER size=" + (modules == null ? "null" : modules.size()));
+        return modules;
+    }
+
     /** @return true if a Home module of this type should be hidden. */
     public static boolean shouldHide(String type) {
-        return type != null && HIDDEN.contains(type);
+        boolean hide = type != null && HIDDEN.contains(type);
+        Log.i(TAG, "module type=" + type + " hide=" + hide);
+        return hide;
     }
 }

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidehomemodules/HideHomeModulesPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidehomemodules/HideHomeModulesPatch.kt
@@ -53,6 +53,8 @@ val hideHomeModulesPatch = bytecodePatch(
         filter.addInstructions(
             0,
             """
+                invoke-static {p0}, Lapp/andrewliang/extension/HomeModules;->onEnter(Ljava/util/List;)Ljava/util/List;
+                move-result-object p0
                 new-instance v0, Ljava/util/ArrayList;
                 invoke-direct {v0}, Ljava/util/ArrayList;-><init>()V
                 invoke-interface {p0}, Ljava/util/List;->iterator()Ljava/util/Iterator;


### PR DESCRIPTION
**Temporary diagnostic — to be reverted after capturing data.** Merging this cuts a pre-release for on-device logcat capture.

## Why
On-device test of "Hide Home modules" hid nothing (not even the bottom ad). The module types are server-driven and can't be mapped to visible sections statically, so this build logs what actually happens at runtime.

## What it adds
`HomeModules` (the filter extension) now logs to logcat under tag **`MorpheHomeModules`**:
- `filterHomeModules ENTER size=N` — one marker when the filter runs (injected at method entry).
- `module type=<type> hide=<bool>` — every Home module type encountered.

`Hide Home modules` is `default = false`, so this only logs when the patch is enabled.

## Capture
```
adb logcat -c && adb logcat -s MorpheHomeModules
```
Open LINE → Home tab → let it load → paste the output.

## How it's read (3-way)
- **No lines** → filter never runs (`i52.c.e` isn't the rendered-list builder) → need a different injection point.
- **ENTER but no `module type=`** → filter runs but the list is empty at that point → wrong timing/builder.
- **`module type=` lines** → the real type strings of the visible sections → set the blocklist precisely.

## Follow-up
Once the types are captured: set the confirmed blocklist, remove this logging, and split into final packaging (ad types → Hide ad views; content → Declutter Home). **Do not leave this logging in a stable release.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
