### PR TITLE
fix: Retarget Hide Home modules to the feed state (x72.h$a)

### DIFF
--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidehomemodules/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidehomemodules/Fingerprints.kt
@@ -1,22 +1,28 @@
 package app.andrewliang.patches.line.hidehomemodules
 
 import app.morphe.patcher.Fingerprint
-import app.morphe.patcher.methodCall
 
 /**
- * `i52.c.e(f0, c): i0` — builds the Home UI state `m52.i0`, whose module list (`List<m52.z>`,
- * each `z.e` a typed `m52.a0` module) is assembled into a register and passed as the 3rd
- * constructor arg. We inject a filter right before that `m52.i0.<init>` call.
+ * `x72.h$a.<init>(List<m52.z>, ...)` — the constructor of the Home Compose UI state that holds
+ * the rendered module list (stored into field `a`, the first ctor arg). Every feed build path
+ * (the v52.g / v52.j assemblers, and state copies) funnels through this constructor, so
+ * filtering the list argument here covers the whole rendered feed in one place.
  *
- * `i52.c` is obfuscated (version-brittle); anchored on the return type `Lm52/i0;`, the
- * `(f0, c)` params, and the `m52.i0.<init>` call the injection is placed before.
+ * (The earlier target `i52.c.e` built only the Friends sub-tab list — a single
+ * `FriendsSubTabFriendsList` module — not the feed with the ad / recommendation sections;
+ * confirmed via on-device logging.)
  */
-internal object HomeStateBuilderFingerprint : Fingerprint(
-    definingClass = "Li52/c;",
-    name = "e",
-    returnType = "Lm52/i0;",
-    parameters = listOf("Lm52/f0;", "Lm52/c;"),
-    filters = listOf(
-        methodCall(definingClass = "Lm52/i0;", name = "<init>"),
+internal object HomeStateCtorFingerprint : Fingerprint(
+    definingClass = "Lx72/h\$a;",
+    name = "<init>",
+    returnType = "V",
+    parameters = listOf(
+        "Ljava/util/List;",
+        "Z", "Z", "Z", "Z", "Z",
+        "Ljava/lang/String;",
+        "Ljava/lang/Long;",
+        "Ljava/lang/Long;",
+        "I",
+        "Z",
     ),
 )

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidehomemodules/HideHomeModulesPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidehomemodules/HideHomeModulesPatch.kt
@@ -9,7 +9,7 @@ import com.android.tools.smali.dexlib2.builder.MutableMethodImplementation
 import com.android.tools.smali.dexlib2.immutable.ImmutableMethod
 import com.android.tools.smali.dexlib2.immutable.ImmutableMethodParameter
 
-private const val I52_C = "Li52/c;"
+private const val HOME_STATE = "Lx72/h\$a;"
 private const val FILTER_NAME = "filterHomeModules"
 private const val FILTER_DESC = "(Ljava/util/List;)Ljava/util/List;"
 
@@ -24,21 +24,20 @@ val hideHomeModulesPatch = bytecodePatch(
 
     extendWith("extensions/extension.mpe")
 
-    // The Home module list (List<m52.z>, each z.e a typed m52.a0 module) is assembled in
-    // i52.c.e and passed as arg3 (register v6) to m52.i0.<init>. We drop modules whose
-    // z.e.getType() is blocklisted.
+    // The rendered Home feed is a List<m52.z> (each z.e a typed m52.a0 module) stored as the
+    // first ctor arg (field `a`) of the Compose state x72.h$a. Filter that list to drop
+    // modules whose z.e.getType() is blocklisted.
     //
-    // The filtering loop lives in its OWN new method (i52.c.filterHomeModules) rather than
-    // being injected inline. Injecting a backward-branching loop into the existing
-    // 126-instruction e() corrupted its branch layout -> runtime VerifyError "target dex pc
-    // not at instruction start". A freshly built method's branches assemble cleanly, and the
-    // call injected into e() is branchless (invoke + move-result), so it can't misalign e().
+    // The filtering loop is a new method x72.h$a.filterHomeModules (backward-branching loops
+    // corrupt an existing method's layout when injected inline -> VerifyError). We then inject
+    // a branchless call at the top of x72.h$a.<init> to replace p1 (the list) with its
+    // filtered copy before it's stored. One constructor covers every feed build path + copies.
     execute {
-        // 1. Add the static filter helper method to i52.c.
-        val cls = mutableClassDefBy(I52_C)
+        // 1. Add the static filter helper method to x72.h$a.
+        val cls = mutableClassDefBy(HOME_STATE)
         val filter = MutableMethod(
             ImmutableMethod(
-                I52_C,
+                HOME_STATE,
                 FILTER_NAME,
                 listOf(ImmutableMethodParameter("Ljava/util/List;", null, null)),
                 "Ljava/util/List;",
@@ -79,14 +78,13 @@ val hideHomeModulesPatch = bytecodePatch(
             """,
         )
 
-        // 2. In e(), replace the module list (v6) with the filtered list right before the
-        //    m52.i0.<init> call. Branchless: just invoke + move-result.
-        val ctorIndex = HomeStateBuilderFingerprint.instructionMatches.first().index
-        HomeStateBuilderFingerprint.method.addInstructions(
-            ctorIndex,
+        // 2. At the top of x72.h$a.<init>, replace the list param (p1) with its filtered copy
+        //    before it is stored. Branchless (invoke + move-result), reuses p1 (`.locals 0`).
+        HomeStateCtorFingerprint.method.addInstructions(
+            0,
             """
-                invoke-static {v6}, $I52_C->$FILTER_NAME$FILTER_DESC
-                move-result-object v6
+                invoke-static {p1}, $HOME_STATE->$FILTER_NAME$FILTER_DESC
+                move-result-object p1
             """,
         )
     }


### PR DESCRIPTION
Retargets the experimental Hide Home modules patch to the correct Home surface, and (still a diagnostic build) captures the real feed module types.

## What the logcat told us
The previous target `i52.c.e` builds only the **Friends sub-tab** list — one `FriendsSubTabFriendsList` module (`filterHomeModules ENTER size=1`). That's not the surface with the bottom ad / 即時夯話題 / recommended stickers. The filter mechanism works; it was pointed at the wrong list.

## Fix
The rendered feed is a `List<m52.z>` held as the first ctor arg (field `a`) of the Compose state **`x72.h$a`** (assembled via `v52.g`/`v52.j` + state copies). Retarget there:
- Add the `filterHomeModules` helper to `x72.h$a`.
- Inject a branchless call at the top of `x72.h$a.<init>` to replace the list param `p1` with its filtered copy before it's stored. One constructor covers every feed build path and copy.

## Still diagnostic
- The blocklist is still the unconfirmed candidate set, and the **`MorpheHomeModules` logging is retained** — so this build ALSO logs the real feed module types.
- `default = false`. This is a `fix:` commit, so merging cuts a `dev` pre-release automatically (no bump needed).

## Test after merge
Install the pre-release, **enable "Hide Home modules"**, then:
```
adb logcat -c && adb logcat -s MorpheHomeModules
```
Open LINE → Home → let it load → paste. Report: which of {bottom ad, 即時夯話題, recommended stickers} disappeared, and the logged `module type=` lines. Then I set the confirmed blocklist and remove the logging.

Verified: builds, applies to LINE 26.11.0; disassembly confirms the helper on `x72.h$a` and the filtered `p1` stored into field `a`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
