### PR TITLE
fix: Home modules blocklist — add FLEX for 即時夯話題 (test round)

### DIFF
--- a/extensions/extension/src/main/java/app/andrewliang/extension/HomeModules.java
+++ b/extensions/extension/src/main/java/app/andrewliang/extension/HomeModules.java
@@ -30,12 +30,13 @@ public final class HomeModules {
     private static final Set<String> HIDDEN = new HashSet<>();
 
     static {
-        // Candidate blocklist (unconfirmed) — bottom ad + recommended content.
-        HIDDEN.add("HomePerformanceAd");
-        HIDDEN.add("AdModel");
-        HIDDEN.add("HomeContentsRecommendation");
-        HIDDEN.add("HomeFeedMatomeCarousel");
-        HIDDEN.add("HomeFeedMatomeSingle");
+        // Confirmed on device:
+        HIDDEN.add("HomeContentsRecommendation"); // recommended stickers (confirmed gone)
+        HIDDEN.add("HomePerformanceAd");          // a performance ad module
+        // Testing this round: 即時夯話題 is most likely FLEX. NOTE there are 2 FLEX modules in
+        // the feed, so this hides BOTH — confirm on device whether it removes 即時夯話題 (and
+        // possibly the bottom ad) without taking any wanted content.
+        HIDDEN.add("FLEX");
     }
 
     /** DIAGNOSTIC: called once at filter entry so "ran but empty/unmatched" is distinguishable


### PR DESCRIPTION
Next test iteration of Hide Home modules, now that on-device logging mapped the feed types.

## Confirmed from your logcat (feed size=8)
- `HomeContentsRecommendation` = **recommended stickers** — confirmed gone ✅
- `HomePerformanceAd` = a performance ad (kept blocklisted).
- Your **bottom ad is NOT** in this feed list (HomePerformanceAd was hidden but the ad still shows) → it is a different surface, tracked separately.
- `HomeSocialGraph` / `HomeServiceList` = friends updates / service icons → **kept** (wanted UI).

## This round
Add **`FLEX`** to the blocklist — 即時夯話題 is most likely a FLEX module. ⚠️ There are **2 FLEX** modules in the feed, so this hides BOTH. Please report:
1. Did **即時夯話題** disappear?
2. Did the **bottom ad** disappear (one FLEX might be it)?
3. Did **anything you want** vanish (the other FLEX)?

Diagnostic `MorpheHomeModules` logging retained; `default = false`. `fix:` → merging cuts a dev pre-release automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)