### PR TITLE
feat: Finalize Hide Home modules (confirmed blocklist, default on)

### DIFF
--- a/extensions/extension/src/main/java/app/andrewliang/extension/HomeModules.java
+++ b/extensions/extension/src/main/java/app/andrewliang/extension/HomeModules.java
@@ -1,55 +1,35 @@
 package app.andrewliang.extension;
 
-import android.util.Log;
-
 import java.util.HashSet;
 import java.util.Set;
 
 /**
- * Helper for hiding LINE Home tab modules.
+ * Helper for the "Hide Home modules" LINE patch.
  *
- * LINE's Home tab is a server-driven list of typed modules (m52.a0, each with a stable
- * getType() string). The patch iterates that list in injected smali and drops modules whose
- * type this helper flags — the extension only makes the String decision (it cannot reference
- * the obfuscated LINE module classes).
+ * LINE's Home tab renders a server-driven list of typed modules (m52.a0, each with a stable
+ * getType() string), held as the module list of the Compose state x72.h$a. The patch iterates
+ * that list in injected smali and drops modules whose type this helper flags — the extension
+ * only makes the String decision (it cannot reference the obfuscated LINE module classes).
  *
- * DIAGNOSTIC BUILD: every module type encountered is logged to logcat under tag
- * "MorpheHomeModules", so the real type strings of the visible Home sections can be captured
- * on device (the type -> visible-section mapping can't be determined statically). Also logs a
- * one-time marker when the filter runs, so we can tell "filter ran but nothing matched" apart
- * from "filter never ran (wrong injection point)". Capture with:
- *   adb logcat -s MorpheHomeModules
- * Once the real types are known, set the blocklist to them and remove the logging.
+ * Blocklist confirmed on device (LINE 26.11.0):
+ *   HomeContentsRecommendation = recommended stickers/content
+ *   HomePerformanceAd          = performance ad modules in the feed
+ *   FLEX                       = 即時夯話題 (real-time hot topics) and the bottom promo/ad block
  */
 public final class HomeModules {
 
     private HomeModules() {}
 
-    private static final String TAG = "MorpheHomeModules";
-
     private static final Set<String> HIDDEN = new HashSet<>();
 
     static {
-        // Confirmed on device:
-        HIDDEN.add("HomeContentsRecommendation"); // recommended stickers (confirmed gone)
-        HIDDEN.add("HomePerformanceAd");          // a performance ad module
-        // Testing this round: 即時夯話題 is most likely FLEX. NOTE there are 2 FLEX modules in
-        // the feed, so this hides BOTH — confirm on device whether it removes 即時夯話題 (and
-        // possibly the bottom ad) without taking any wanted content.
+        HIDDEN.add("HomeContentsRecommendation");
+        HIDDEN.add("HomePerformanceAd");
         HIDDEN.add("FLEX");
-    }
-
-    /** DIAGNOSTIC: called once at filter entry so "ran but empty/unmatched" is distinguishable
-     *  from "never ran". Returns the list unchanged. */
-    public static java.util.List onEnter(java.util.List modules) {
-        Log.i(TAG, "filterHomeModules ENTER size=" + (modules == null ? "null" : modules.size()));
-        return modules;
     }
 
     /** @return true if a Home module of this type should be hidden. */
     public static boolean shouldHide(String type) {
-        boolean hide = type != null && HIDDEN.contains(type);
-        Log.i(TAG, "module type=" + type + " hide=" + hide);
-        return hide;
+        return type != null && HIDDEN.contains(type);
     }
 }

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidehomemodules/HideHomeModulesPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidehomemodules/HideHomeModulesPatch.kt
@@ -16,9 +16,9 @@ private const val FILTER_DESC = "(Ljava/util/List;)Ljava/util/List;"
 @Suppress("unused")
 val hideHomeModulesPatch = bytecodePatch(
     name = "Hide Home modules",
-    description = "Hides selected Home-tab modules (bottom ad, recommended content sections). " +
-        "EXPERIMENTAL — blocklist being tuned.",
-    default = false, // opt-in until the type blocklist is confirmed on device.
+    description = "Hides Home-tab clutter modules: the recommended stickers/content section, " +
+        "the real-time hot-topics (即時夯話題) block, and Home feed ads.",
+    default = true,
 ) {
     compatibleWith(COMPATIBILITY_LINE)
 
@@ -52,8 +52,6 @@ val hideHomeModulesPatch = bytecodePatch(
         filter.addInstructions(
             0,
             """
-                invoke-static {p0}, Lapp/andrewliang/extension/HomeModules;->onEnter(Ljava/util/List;)Ljava/util/List;
-                move-result-object p0
                 new-instance v0, Ljava/util/ArrayList;
                 invoke-direct {v0}, Ljava/util/ArrayList;-><init>()V
                 invoke-interface {p0}, Ljava/util/List;->iterator()Ljava/util/Iterator;


### PR DESCRIPTION
Finalizes the experimental Hide Home modules patch after device confirmation.

## Confirmed on device
The filter (on `x72.h$a`s module list) hides exactly these feed module types, with no wanted content removed:
- `HomeContentsRecommendation` → recommended stickers
- `FLEX` → 即時夯話題 (real-time hot topics) **and** the bottom promo/ad block
- `HomePerformanceAd` → feed performance ads

## This commit
- Locks the blocklist to those three.
- Removes the diagnostic `MorpheHomeModules` logging (onEnter + per-type) and its injected call.
- Flips `default = true`.

Mechanism is unchanged from the build you confirmed working — this is a subtractive cleanup (drop logging) + enable-by-default, so it is functionally identical to the tested build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)