### PR TITLE
feat: Add LINE rename-package patch (opt-in, package attr only)

### DIFF
--- a/patches/src/main/kotlin/app/andrewliang/patches/line/renamepackage/RenamePackagePatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/renamepackage/RenamePackagePatch.kt
@@ -1,0 +1,29 @@
+package app.andrewliang.patches.line.renamepackage
+
+import app.andrewliang.patches.shared.Constants.COMPATIBILITY_LINE
+import app.morphe.patcher.patch.resourcePatch
+
+private const val NEW_PACKAGE = "app.andrewliang.line.android"
+
+@Suppress("unused")
+val renamePackagePatch = resourcePatch(
+    name = "Rename package",
+    description = "Renames the app package to $NEW_PACKAGE so a patched, re-signed build is a " +
+        "distinct app the Play Store never auto-updates. WARNING: because LINE's identity is " +
+        "tied to its package name, this will likely break push notifications and may break " +
+        "login. It cannot be installed alongside the stock LINE (uninstall that first). Opt-in.",
+    default = false,
+) {
+    compatibleWith(COMPATIBILITY_LINE)
+
+    // Change ONLY the manifest `package` attribute (the applicationId Play keys updates off).
+    // Deliberately leave provider authorities / permissions as jp.naver.line.android.* so they
+    // stay consistent with the strings LINE's own code uses — renaming them would break
+    // features whose code references the old authority (e.g. FileProvider file/image sharing).
+    // Authorities only need to differ for side-by-side coexistence, which is not the goal here.
+    execute {
+        document("AndroidManifest.xml").use { document ->
+            document.documentElement.setAttribute("package", NEW_PACKAGE)
+        }
+    }
+}


### PR DESCRIPTION
Opt-in `resourcePatch` that renames the app package `jp.naver.line.android` → `app.andrewliang.line.android`, so a patched (re-signed) build is a **distinct app the Play Store never auto-updates**.

## What it changes
**Only** the AndroidManifest.xml `package` attribute (the applicationId Play keys updates off).

Provider authorities and permissions are **deliberately left as `jp.naver.line.android.*`** — they stay consistent with the strings LINE's own code uses, so provider-backed features (e.g. `FileProvider` file/image sharing) keep working. Renaming authorities is only needed for *side-by-side coexistence* with stock LINE, which is not the goal here.

## ⚠️ Risks (default = false)
Changing the package identity is inherent to the goal, so:
- **Push notifications will likely break** (FCM is applicationId-bound) — high confidence.
- **Login may break** (if LINE validates the package).
- **Cannot be installed alongside stock LINE** (shared provider authorities) — uninstall stock LINE first.

Note: re-signing already blocks Play auto-update; this makes it explicit by giving the app a distinct identity.

## Verification
Builds; applies to LINE 26.11.0; patched manifest shows the `package` attribute renamed while the 13 provider authorities and all class `android:name`s are unchanged. Device behavior (install, login, push) is the manual check.

`feat:` → merging cuts a `dev` pre-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
