### PR TITLE
feat: Add hide-calendar-button and hide-community-button patches

### DIFF
--- a/patches/src/main/kotlin/app/andrewliang/patches/line/chatheaderbuttons/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/chatheaderbuttons/Fingerprints.kt
@@ -1,0 +1,33 @@
+package app.andrewliang.patches.line.chatheaderbuttons
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.fieldAccess
+import app.morphe.patcher.methodCall
+
+private const val BUTTON_ENUM = "Laz0/q;"
+
+/**
+ * The Chats-tab header button set is built in the ChatTabHeaderStateImpl constructor
+ * (obfuscated), which adds each button as `sget-object <az0.q constant>` + `add(...)` to the
+ * button list. The button enum constant names (CALENDAR, OPEN_CHAT, …) are non-obfuscated
+ * (Kotlin enum names survive), so we anchor on them.
+ *
+ * Each fingerprint matches its own enum constant's `sget-object` immediately followed by the
+ * list `add` call — that pair uniquely lands in the constructor (the enum's WhenMappings
+ * table accesses the same constants but follows them with `ordinal()`, not `add`). Anchoring
+ * each button independently means the two patches don't depend on each other and work in
+ * either order when both are enabled.
+ */
+internal object CalendarButtonFingerprint : Fingerprint(
+    filters = listOf(
+        fieldAccess(definingClass = BUTTON_ENUM, name = "CALENDAR"),
+        methodCall(name = "add"),
+    ),
+)
+
+internal object CommunityButtonFingerprint : Fingerprint(
+    filters = listOf(
+        fieldAccess(definingClass = BUTTON_ENUM, name = "OPEN_CHAT"),
+        methodCall(name = "add"),
+    ),
+)

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/chatheaderbuttons/HideCalendarButtonPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/chatheaderbuttons/HideCalendarButtonPatch.kt
@@ -1,0 +1,22 @@
+package app.andrewliang.patches.line.chatheaderbuttons
+
+import app.andrewliang.patches.shared.Constants.COMPATIBILITY_LINE
+import app.morphe.patcher.extensions.InstructionExtensions.removeInstructions
+import app.morphe.patcher.patch.bytecodePatch
+
+@Suppress("unused")
+val hideCalendarButtonPatch = bytecodePatch(
+    name = "Hide calendar button",
+    description = "Removes the calendar button from the top of the Chats tab header.",
+    default = true,
+) {
+    compatibleWith(COMPATIBILITY_LINE)
+
+    // Remove the `sget-object CALENDAR` + following `add(...)` pair so the button is never
+    // added to the header list. instructionMatches[0] = the CALENDAR sget-object; the add is
+    // the immediately-following instruction.
+    execute {
+        val calendarSgetIndex = CalendarButtonFingerprint.instructionMatches.first().index
+        CalendarButtonFingerprint.method.removeInstructions(calendarSgetIndex, 2)
+    }
+}

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/chatheaderbuttons/HideCommunityButtonPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/chatheaderbuttons/HideCommunityButtonPatch.kt
@@ -1,0 +1,22 @@
+package app.andrewliang.patches.line.chatheaderbuttons
+
+import app.andrewliang.patches.shared.Constants.COMPATIBILITY_LINE
+import app.morphe.patcher.extensions.InstructionExtensions.removeInstructions
+import app.morphe.patcher.patch.bytecodePatch
+
+@Suppress("unused")
+val hideCommunityButtonPatch = bytecodePatch(
+    name = "Hide community button",
+    description = "Removes the community (OpenChat) button from the top of the Chats tab header.",
+    default = true,
+) {
+    compatibleWith(COMPATIBILITY_LINE)
+
+    // Remove the `sget-object OPEN_CHAT` + following `add(...)` pair so the button is never
+    // added to the header list. instructionMatches[0] = the OPEN_CHAT sget-object; the add is
+    // the immediately-following instruction.
+    execute {
+        val openChatSgetIndex = CommunityButtonFingerprint.instructionMatches.first().index
+        CommunityButtonFingerprint.method.removeInstructions(openChatSgetIndex, 2)
+    }
+}


### PR DESCRIPTION
Two patches to remove the **calendar** and **community (OpenChat)** buttons from the top of the Chats tab header.

## How
Both buttons are added in the `ChatTabHeaderStateImpl` constructor as `sget-object <az0.q enum constant>` + list `add(...)`. Each patch removes its enum's `sget`+`add` pair, so the button is never added to the header (same clean mechanism as the tab-hide patches).

Anchored on the **non-obfuscated Kotlin enum names** `CALENDAR` / `OPEN_CHAT` plus the following `add` call — that pair uniquely identifies the constructor (the enum WhenMappings table references the same constants but with `ordinal()`, not `add`). The two patches share no fingerprint state, so they apply in either order and coexist.

## Verification
Builds; applied BOTH together to LINE 26.11.0; disassembly confirms CALENDAR and OPEN_CHAT are gone from the header builder while AI_FRIEND, ALBUM, and PLUS_MENU remain. `default = true`. Device check: the two icons should be absent from the Chats-tab header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)