### PR TITLE
docs: Add special thanks to @f870103

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Or manually add this repository url as a patch source in Morphe: https://github.
 To build Andrew's Patches,
 you can follow the [Morphe documentation](https://github.com/MorpheApp/morphe-documentation).
 
+## 🙏 Special thanks
+
+- [@f870103](https://github.com/f870103) — for lending a LINE account for testing.
+
 ## 📜 License
 
 Andrew's Patches are licensed under the [GNU General Public License v3.0](LICENSE)


### PR DESCRIPTION
Adds a Special thanks section to the README crediting [@f870103](https://github.com/f870103) for lending a LINE account for testing.

Placed outside the generated `<!-- PATCHES_START -->…<!-- PATCHES_END -->` block, so it survives release-time README regeneration. `docs:` commit → does **not** trigger a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)