### PR TITLE
feat: hide Transfer and LINE GIFT buttons in + attach menu

### DIFF
--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidegift/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidegift/Fingerprints.kt
@@ -1,0 +1,25 @@
+package app.andrewliang.patches.line.hidegift
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.fieldAccess
+
+/**
+ * The "+" attach-menu **LINE GIFT** tile is `hg1.h`, an `hg1.r` subclass. Its constructor is the
+ * only method that READS the attach-item type constant `fg1.a$b.GIFT` (`sget`); the enum's own
+ * `<clinit>` merely writes it (`sput`), and the constructor's parameter list excludes that clinit.
+ * From the resolved constructor we take `definingClass` (`Lhg1/h;`) and neuter the class's
+ * availability predicate `j(...)`.
+ */
+internal object GiftAttachButtonFingerprint : Fingerprint(
+    returnType = "V",
+    parameters = listOf(
+        "Ln/c;",
+        "Lr11/b;",
+        "Lgg1/c;",
+        "Laf1/d3\$e;",
+        "Laf1/c2;",
+    ),
+    filters = listOf(
+        fieldAccess(definingClass = "Lfg1/a\$b;", name = "GIFT"),
+    ),
+)

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidegift/HideGiftButtonPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidegift/HideGiftButtonPatch.kt
@@ -1,0 +1,33 @@
+package app.andrewliang.patches.line.hidegift
+
+import app.andrewliang.patches.shared.Constants.COMPATIBILITY_LINE
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.bytecodePatch
+
+@Suppress("unused")
+val hideGiftButtonPatch = bytecodePatch(
+    name = "Hide LINE GIFT button",
+    description = "Removes the LINE GIFT tile from a chat room's + attach menu.",
+    default = true,
+) {
+    compatibleWith(COMPATIBILITY_LINE)
+
+    // The LINE GIFT tile (hg1.h) is shown only if its availability predicate `j(gi1.b)Z` returns
+    // true (the attach-menu filter hg1.r.f gates on it). Neuter that predicate to false; the tile
+    // is then dropped by the existing filter in gg1.e. Anchor via the constructor (the sole reader
+    // of the fg1.a$b.GIFT enum constant), then select `j` by its unique descriptor.
+    execute {
+        val giftClass = mutableClassDefBy(GiftAttachButtonFingerprint.method.definingClass)
+        val availabilityMethod = giftClass.methods.first { method ->
+            method.returnType == "Z" &&
+                method.parameterTypes.map { it.toString() } == listOf("Lgi1/b;")
+        }
+        availabilityMethod.addInstructions(
+            0,
+            """
+                const/4 p0, 0x0
+                return p0
+            """,
+        )
+    }
+}

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidetransfer/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidetransfer/Fingerprints.kt
@@ -1,0 +1,28 @@
+package app.andrewliang.patches.line.hidetransfer
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.fieldAccess
+
+/**
+ * The "+" attach-menu **Transfer** tile (LINE Pay money transfer) is `hg1.k`, an `hg1.r` subclass.
+ * Its constructor is the only method that READS the attach-item type constant `fg1.a$b.PAY`
+ * (`sget`); the enum's own `<clinit>` merely writes it (`sput`), and the constructor's parameter
+ * list excludes that clinit. From the resolved constructor we take `definingClass` (`Lhg1/k;`) and
+ * neuter the class's availability predicate `j(...)`.
+ */
+internal object TransferAttachButtonFingerprint : Fingerprint(
+    returnType = "V",
+    parameters = listOf(
+        "Ln/c;",
+        "Lac3/b;",
+        "Lmm3/c;",
+        "Lv01/c;",
+        "Lr11/b;",
+        "Lgg1/c;",
+        "Lna1/k;",
+        "Laf1/d3\$e;",
+    ),
+    filters = listOf(
+        fieldAccess(definingClass = "Lfg1/a\$b;", name = "PAY"),
+    ),
+)

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidetransfer/HideTransferButtonPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidetransfer/HideTransferButtonPatch.kt
@@ -1,0 +1,34 @@
+package app.andrewliang.patches.line.hidetransfer
+
+import app.andrewliang.patches.shared.Constants.COMPATIBILITY_LINE
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.bytecodePatch
+
+@Suppress("unused")
+val hideTransferButtonPatch = bytecodePatch(
+    name = "Hide Transfer button",
+    description = "Removes the Transfer (LINE Pay) tile from a chat room's + attach menu.",
+    default = true,
+) {
+    compatibleWith(COMPATIBILITY_LINE)
+
+    // The Transfer tile (hg1.k) is shown only if its availability predicate `j(gi1.b)Z` returns
+    // true (the attach-menu filter hg1.r.f gates on it). Neuter that predicate to false; the tile
+    // is then dropped by the existing filter in gg1.e. Anchor via the constructor (the sole reader
+    // of the fg1.a$b.PAY enum constant), then select `j` by its unique descriptor.
+    execute {
+        val transferClass =
+            mutableClassDefBy(TransferAttachButtonFingerprint.method.definingClass)
+        val availabilityMethod = transferClass.methods.first { method ->
+            method.returnType == "Z" &&
+                method.parameterTypes.map { it.toString() } == listOf("Lgi1/b;")
+        }
+        availabilityMethod.addInstructions(
+            0,
+            """
+                const/4 p0, 0x0
+                return p0
+            """,
+        )
+    }
+}


### PR DESCRIPTION
## What

Two independent, default-on patches that remove tiles from a chat room's **+** attach menu:

| Patch | Tile | Target class | Suppression |
|-------|------|--------------|-------------|
| **Hide Transfer button** | Transfer (LINE Pay) | `hg1.k` | availability predicate `j(gi1.b)Z` forced to return false |
| **Hide LINE GIFT button** | LINE GIFT | `hg1.h` | availability predicate `j(gi1.b)Z` forced to return false |

Both are static `hg1.r` attach-grid items, shown only when `j()` returns true (the attach-menu filter `hg1.r.f` gates on it). Each patch anchors its class via the unique read of its `fg1.a$b` type constant in the constructor (`PAY` for Transfer, `GIFT` for LINE GIFT — each read only in that one ctor), then forces `j()` false so the tile is dropped. This is the same, already-verified technique used for the calendar attach tile.

Two separate patches (not one) per the one-patch-per-feature convention — each is independently toggleable in the Manager.

## Verification

Built and **applied both against the real LINE 26.11.0 APK**, then disassembled the patched dex:
- Both appear as distinct patches in `list-patches`.
- Exactly **2** classes modified (`hg1.k`, `hg1.h`).
- `Lhg1/k;->j(Lgi1/b;)Z` and `Lhg1/h;->j(Lgi1/b;)Z` each start with `const/4 v0,0x0 / return v0`.

⚠️ **On-device UI confirmation pending** — needs a device (open a chat, tap +, confirm the Transfer and LINE GIFT tiles are gone and the other tiles remain).

## Release

Two `feat:`-worthy patches in one commit → minor bump via semantic-release on `dev → main`. `patches-list.json` / `patches-bundle.json` left for the release bot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
