### PR TITLE
feat: hide all server-driven extra tools in the + attach menu

### DIFF
--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hideattachmenutools/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hideattachmenutools/Fingerprints.kt
@@ -1,0 +1,23 @@
+package app.andrewliang.patches.line.hideattachmenutools
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.fieldAccess
+
+/**
+ * The chat "+" attach menu's server-driven "services" (Poll, Schedule, Reservation, Ladder shuffle,
+ * …) are all rendered by the single shared class `hg1.d` (ChatAppButtonType) — the only class
+ * built from the server-fetched `r51.a` (ChatAppViewData) list, in `gg1.e`. Each item is shown only
+ * when its per-item gate `f(Lgi1/b;Lfg1/a;Lhg1/a$a;)Z` returns true.
+ *
+ * We match `hg1.d`'s `f()` override directly: it is the only method with that signature that reads
+ * `Lr51/a;->f` (the item's availableChatTypes set) — the sibling `f()` overrides in `hg1.a`/`hg1.r`
+ * gate on other data, never on `Lr51/a;`. Forcing it false drops every server service at once, with
+ * no dependency on any (drifting) server channel id.
+ */
+internal object AttachMenuServiceGateFingerprint : Fingerprint(
+    returnType = "Z",
+    parameters = listOf("Lgi1/b;", "Lfg1/a;", "Lhg1/a\$a;"),
+    filters = listOf(
+        fieldAccess(definingClass = "Lr51/a;", name = "f"),
+    ),
+)

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hideattachmenutools/HideAttachMenuExtraToolsPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hideattachmenutools/HideAttachMenuExtraToolsPatch.kt
@@ -1,0 +1,31 @@
+package app.andrewliang.patches.line.hideattachmenutools
+
+import app.andrewliang.patches.shared.Constants.COMPATIBILITY_LINE
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.bytecodePatch
+
+@Suppress("unused")
+val hideAttachMenuExtraToolsPatch = bytecodePatch(
+    name = "Hide attach menu extra tools",
+    description = "Removes all the server-provided extra tools from a chat room's + attach menu " +
+        "(Poll, Reservation, Schedule, Ladder shuffle, and any others). The built-in tiles " +
+        "(camera, gallery, files, contact, etc.) are unaffected.",
+    default = true,
+) {
+    compatibleWith(COMPATIBILITY_LINE)
+
+    // Every server-driven attach service is rendered by the shared class hg1.d, shown only when its
+    // per-item gate f(...) returns true. hg1.d is the sole renderer of these services, so forcing
+    // its f() to unconditionally return false drops the entire set — with no dependency on any
+    // server channel id (the reason a single-service patch can't be stable). p0 is `this`;
+    // clobbering it is fine since we return immediately.
+    execute {
+        AttachMenuServiceGateFingerprint.method.addInstructions(
+            0,
+            """
+                const/4 p0, 0x0
+                return p0
+            """,
+        )
+    }
+}


### PR DESCRIPTION
## What

New patch **"Hide attach menu extra tools"** — removes the entire set of **runtime/server-driven services** from a chat room's **+** attach menu (Poll, Reservation, Schedule, Ladder shuffle, Gather, Split bill, and any others the server sends). The built-in tiles (camera, gallery, files, contact, Calendar, Pay, LINE GIFT, Keep, Location, Voice, Message scheduler) are **unaffected**.

## How

These services are all rendered by one shared class, `hg1.d` (ChatAppButtonType) — built only from the server-fetched `r51.a` list in `gg1.e`, and shown only when its per-item gate `f(Lgi1/b;Lfg1/a;Lhg1/a$a;)Z` returns true. The patch forces that gate to return false:

```
Lhg1/d;->f(...)Z:  const/4 v0, 0x0 / return v0
```

`hg1.d.f` is matched specifically via the field read `Lr51/a;->f`, which is unique to it among the `f()` overrides (`hg1.a`/`hg1.r` gate on other data).

## Why category-level (not per service)

Hiding a *single* server service can only key off its server **channel id** (e.g. Schedule = `1655112642`), which drifts server-side and can't be pinned to an APK version — fragile. Killing the shared render gate depends on **no ids at all**, so it's stable and also covers any future/region-specific services automatically. It's all-or-nothing by design.

## Verification

Built and **applied against real LINE 26.11.0**, then disassembled:
- Registers as "Hide attach menu extra tools" in `list-patches`.
- Exactly **1** class modified (`hg1.d`).
- `Lhg1/d;->f(Lgi1/b;Lfg1/a;Lhg1/a$a;)Z` starts with `const/4 v0,0x0 / return v0`.

⚠️ **On-device UI confirmation pending** — open a chat, tap +, confirm the extra services (Poll, Reservation, Schedule, Ladder shuffle, …) are gone and the built-in tiles remain.

## Release

`feat:` → minor bump via semantic-release on `dev → main`. Independent of PR #23 (calendar) and PR #24 (Transfer/GIFT). `patches-list.json` / `patches-bundle.json` left for the release bot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
