### PR TITLE
docs: LINE + attach-menu / calendar patch map and local verify recipe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,4 +92,3 @@ Fingerprint authoring relies on inspecting LINE's bytecode.
 These live outside the repo / are gitignored:
 
 - **`work/decompiled-line-<version>/`** (gitignored) — decompiled LINE. `apktool/` has smali (what fingerprints match against) + resources; `jadx/` has readable Java for understanding logic. Regenerate with `apktool d` / `jadx` from `work/apkm-extract/base.apk`. Anchor grep across `apktool/smali*` for strings/classes.
-- **LIME-Reborn** (`../LIME-Reborn`) — a runtime **Xposed/LSPatch** module that hooks the same LINE app. Great prior art for *what* to patch: `app/src/.../hooks/*.java` (RemoveAds, PreventMarkAsRead, KeepUnread, …) and `hooks/Constants.java` (obfuscated target class/method names). Caveat: it hooks at runtime, so hooks that touch framework classes (e.g. `Notification.Builder`) or build runtime UI do **not** port to Morphe's ahead-of-time bytecode approach.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,8 @@ There is no test suite. Correctness is validated by applying the built `.mpp` wi
 
 `settings.gradle.kts` pulls the `app.morphe.patches` Gradle plugin and patcher libraries from GitHub Packages (`maven.pkg.github.com/MorpheApp/registry`). Building requires `gpr.user`/`gpr.key` Gradle properties **or** `GITHUB_ACTOR`/`GITHUB_TOKEN` env vars with a PAT that can read those packages.
 
+**Local build/verify without a PAT:** if the patcher/plugin artifacts are already in the Gradle cache, build fully offline with *dummy* credential values — `./gradlew :patches:buildAndroid --offline --no-daemon -Pgpr.user=dummy -Pgpr.key=dummy` (the settings plugin only needs the credentials to be non-null when nothing is fetched). Then apply with the bundled Morphe CLI (`java -jar work/morphe-desktop-*.jar patch --exclusive -e "<name>" -o work/out.apk … work/apkm-extract/base.apk`) and inspect the patched dex with **dexlib2** (no `baksmali` CLI ships — STRIP_FAST writes modified classes into a small fresh `classes.dex`). Full recipe + the LINE class/anchor map live in **`docs/line-patch-map.md`**.
+
 ## Architecture
 
 Two Gradle modules (`settings.gradle.kts`):
@@ -46,6 +48,9 @@ The patching model is: **fingerprint → locate method → inject smali → opti
 ### Patcher API notes (hard-won)
 
 - **Finding instruction indices:** there is no `indexOfFirstInstructionOrThrow` (that's ReVanced). Use `fingerprint.instructionMatches[i].index` — one match per instruction `filter`, in program order — or `instructionMatchesOrNull` for best-effort. `.method` and `.instructionMatches` are context-receiver accessors usable inside `execute { }`.
+- **Instruction filter builders** (imported from `app.morphe.patcher`): `fieldAccess`, `methodCall`, `string`, `literal`, `opcode`, `checkCast`, `instanceOf`, `newInstance`. Two *identical* filters match the first two occurrences in program order — use this to grab both sites of a repeated `sget`+`add` pair in one method (see `hidewallettab`). `fieldAccess` matches both reads and writes, so pin the ctor (parameters) when a field is also `sput` in an enum `<clinit>`.
+- **Reading a matched instruction's operands:** `fingerprint.instructionMatches[i].instruction` returns the dexlib2 `Instruction`; cast it (e.g. `as TwoRegisterInstruction`) to read `.registerA`. Lets you "replace this `iget` with a `const 0` into its *own* destination register" without hardcoding the register (see `hideevents`: `removeInstruction(idx)` + `addInstructions(idx, "const/16 v$reg, 0x0")`).
+- **Hiding a UI list item:** LINE lists (attach-menu tiles, chat-menu rows, context-menu actions) render each entry through a per-item availability predicate; force *that* predicate false rather than editing the (often shared or looping) list builder. To hide a **whole server-driven category**, neuter the shared renderer's gate — stable, no ids (see `hideattachmenutools` → `hg1.d.f()`); to hide **one** server item you must match an id/type that can drift server-side — fragile, avoid. Details/anchors in `docs/line-patch-map.md`.
 - **Register operand limits:** `invoke-*` (format 35c) and `iget/iput` (22c) take **4-bit register operands — only v0–v15**. Referencing v16+ there is silently dropped/mis-assembled (the filter/injection appears to apply but does nothing). Use a low free register, or the `/range` instruction variants.
 - **Don't inject a backward-branching loop into an existing method** — it can corrupt that method's branch layout and throw a runtime `VerifyError` ("target dex pc … not at instruction start"). Instead extract the loop into a **new** method (`mutableClassDefBy(desc).methods.add(MutableMethod(ImmutableMethod(...)))`, then `addInstructions`) and inject only a branchless `invoke-static` + `move-result` at the call site (see `hidehomemodules`).
 - **Targeting a method in an obfuscated class:** fingerprint a *sibling* on a stable anchor (a non-obfuscated framework/API call or string literal), then `mutableClassDefBy(fp.method.definingClass)` and select the target method by descriptor (`returnType` + `parameterTypes`) — see `keepunread` anchoring on `TalkServiceClient.j1`.
@@ -80,7 +85,11 @@ Releases are fully automated by **semantic-release** (`.releaserc`, `.github/wor
 
 ## Decompiled reference & prior art
 
-Fingerprint authoring relies on inspecting LINE's bytecode. These live outside the repo / are gitignored:
+Fingerprint authoring relies on inspecting LINE's bytecode.
+
+- **`docs/line-patch-map.md`** (tracked) — the LINE `+` attach menu architecture (static `hg1.r` tiles vs server-driven `hg1.d` services), the Calendar vs Events vs Message-scheduler feature map, per-surface class/anchor references for the shipped patches, and the offline build + dexlib2 disassembly recipe. Update it when bumping the pinned LINE version (the obfuscated descriptors drift).
+
+These live outside the repo / are gitignored:
 
 - **`work/decompiled-line-<version>/`** (gitignored) — decompiled LINE. `apktool/` has smali (what fingerprints match against) + resources; `jadx/` has readable Java for understanding logic. Regenerate with `apktool d` / `jadx` from `work/apkm-extract/base.apk`. Anchor grep across `apktool/smali*` for strings/classes.
 - **LIME-Reborn** (`../LIME-Reborn`) — a runtime **Xposed/LSPatch** module that hooks the same LINE app. Great prior art for *what* to patch: `app/src/.../hooks/*.java` (RemoveAds, PreventMarkAsRead, KeepUnread, …) and `hooks/Constants.java` (obfuscated target class/method names). Caveat: it hooks at runtime, so hooks that touch framework classes (e.g. `Notification.Builder`) or build runtime UI do **not** port to Morphe's ahead-of-time bytecode approach.

--- a/docs/line-patch-map.md
+++ b/docs/line-patch-map.md
@@ -1,0 +1,170 @@
+# LINE patch map & findings
+
+Reference notes for authoring LINE (`jp.naver.line.android`) patches, distilled from decompiling
+**LINE 26.11.0** (the version pinned in `app/andrewliang/patches/shared/Constants.kt`).
+
+> ⚠️ **Obfuscation drift.** Class/method names like `hg1.d`, `az0.q`, `d00.z`, `ne1.y0$c`,
+> `fg1.a$b`, `r51.a` are R8-obfuscated and **change between LINE versions**. The *concepts,
+> mechanisms, and anchoring strategies* below are durable; the exact descriptors must be
+> re-confirmed against the decompiled smali when bumping the target version. Prefer anchors that
+> survive obfuscation: Kotlin **enum-constant names** (`CALENDAR`, `GIFT`, …), **string literals**,
+> and **resource ids**.
+
+---
+
+## Local build & verify without GitHub Packages credentials
+
+Building normally needs a PAT for `maven.pkg.github.com/MorpheApp/registry`. If the patcher/plugin
+artifacts are already in the Gradle cache, you can build and verify **fully offline** — the
+`app.morphe.patches` settings plugin only requires the credential values to be *non-null*, not
+valid, when nothing is fetched:
+
+```bash
+# Compile + build the bundle offline (dummy creds satisfy the non-null credential block)
+rm -rf patches/build/libs
+./gradlew :patches:buildAndroid --offline --no-daemon -Pgpr.user=dummy -Pgpr.key=dummy
+
+# List patches in the built bundle (confirm name/description/registration)
+java -jar work/morphe-desktop-*.jar list-patches --patches patches/build/libs/patches-*.mpp
+
+# Apply ONE patch exclusively against the real APK (fingerprints resolve here, not at build time)
+java -jar work/morphe-desktop-*.jar patch \
+  -p patches/build/libs/patches-*.mpp \
+  --exclusive -e "<patch name>" \
+  -o work/out.apk -t "$TMPDIR/scratch" \
+  work/apkm-extract/base.apk
+```
+
+The apply log prints `Applied: <name>` and `Writing N new classes` — **N is the number of classes
+your patch modified**, a fast sanity check (e.g. the Calendar patch touches 5, the attach-tools
+patch touches 1).
+
+**Disassembling the result.** The Morphe/apktool jars bundle only the smali *assembler*
+(`com.android.tools.smali.smali.Main`) and a proguard-shrunk `baksmali` **library** with no CLI —
+so there is no ready `baksmali` command. `apktool d` on the full APK works but is slow. The fast
+path: STRIP_FAST (the default) writes every modified class into a fresh small `classes.dex`, so
+unzip just that and read it with **dexlib2** (available in the Gradle cache jar
+`smali-dexlib2-*.jar`):
+
+```java
+// javac -cp smali-dexlib2-*.jar:smali-util-*.jar Dump.java && java -cp .:...:... Dump
+var dex = DexBackedDexFile.fromInputStream(Opcodes.getDefault(),
+              new BufferedInputStream(new FileInputStream("classes.dex")));
+for (ClassDef c : dex.getClasses())
+    for (Method m : c.getMethods()) { /* inspect m.getImplementation().getInstructions() */ }
+```
+
+Cast instructions to `OneRegisterInstruction` / `TwoRegisterInstruction` /
+`NarrowLiteralInstruction` / `ReferenceInstruction` to print registers, literals, and field/method
+references.
+
+---
+
+## Chat "+" attach menu
+
+Built by **`gg1.e.r(boolean)`** (`smali_classes9/gg1/e.smali`; jadx `gg1/e.java`), the RecyclerView
+adapter for the attach grid (item layout `R.layout.chat_ui_attach_grid_item`). It concatenates two
+kinds of items into one `[Lhg1/a;` array, then keeps each only if `((hg1.a) item).f(...)` returns
+true:
+
+1. **Static local tiles** — one `hg1.r` subclass each, constructed inline in `gg1.e.r()`.
+2. **Server-driven services** — a runtime-fetched list (`r11.d.c()` → `List<r51.a>`); each entry
+   becomes one `hg1.d` (the single shared "ChatAppButtonType" class), built in the loop at
+   `gg1/e.smali:827`. If the list isn't cached yet it returns `[]` and kicks off an async fetch,
+   then re-renders.
+
+### Item gates (`hg1.r` / `hg1.a`)
+
+`hg1.r.f(Lgi1/b;Lfg1/a;Lhg1/a$a;)Z` is the visibility gate. It shows an item only when: the chat
+type is in the item's allowed set **AND** `j(Lgi1/b;)Z` (per-type availability) **AND** `k(...)`
+**AND** `l(...)` all pass. So **forcing `j()` false hides a static tile**; forcing `f()` false hides
+whatever class owns that `f()`.
+
+### Static tiles (LINE 26.11.0)
+
+| Tile (label) | Class | ctor type constant (`Lfg1/a$b;->…`) | `j()` availability |
+|---|---|---|---|
+| Calendar (`line_calendar_plusmenu_calendar`) | `hg1.b` | `CALENDAR` | `return true` |
+| Message scheduler (`chat_plusmenu_button_scheduledmessages`) | `hg1.s` | `SCHEDULED_MESSAGE` | schedule-a-message composer |
+| Transfer / LINE Pay (`chathistory_attach_dialog_label_select_linepay`) | `hg1.k` | `PAY` | `contains(dl3.a.PAY)` |
+| LINE GIFT (`chathistory_attach_dialog_label_giftshop`) | `hg1.h` | `GIFT` | `contains(dl3.a.GIFT)` |
+| Files `hg1.g`, Contact `hg1.f`, Location `hg1.m`, Voice `hg1.t`, Keep `hg1.i`, PayPay `hg1.p`, Live talk `hg1.l`, LINE MUSIC `hg1.n` | — | (their own) | — |
+
+**To hide one static tile** (pattern used by "Hide Transfer button" / "Hide LINE GIFT button", and
+the Calendar `+` tile): anchor its ctor via the **unique read of its `fg1.a$b` type constant**
+(each constant is read only in that one ctor; the enum's `<clinit>` `sput` is excluded by pinning
+the ctor's parameter list), then `mutableClassDefBy(fp.method.definingClass)`, select
+`j(Lgi1/b;)Z` by descriptor, and prepend `const/4 p0, 0x0` / `return p0`.
+
+### Server-driven services — Poll, Reservation, Schedule, Ladder shuffle, …
+
+These come from the server (category `e38.a.EnumC2123a.MORE`, mapped `e38.a`→`r51.a` in `r11.e.c()`).
+`r51.a` (ChatAppViewData) = `{id, name, iconUrl, url, showNewBadge, availableChatTypes}` — labels,
+icons and destinations all come from the server payload, **not** from local resources. (The
+`chathistory_attach_dialog_label_poll/schedule/ladder_shuffle/reservation` strings still exist in
+`res/` but are **dead** — unreferenced by any smali.)
+
+- **Hide the whole category (stable):** every service is an `hg1.d`, and `hg1.d` is built *only* in
+  `gg1.e` — so forcing **`hg1.d.f(Lgi1/b;Lfg1/a;Lhg1/a$a;)Z`** to `return false` drops them all at
+  once, with no dependency on the (drifting) server payload. This is what **"Hide attach menu extra
+  tools"** does. Anchor: `hg1.d.f` is the only `f(...)Z` that reads `Lr51/a;->f` (its
+  `availableChatTypes` set), which uniquely distinguishes it from the sibling `f()` overrides in
+  `hg1.a`/`hg1.r`.
+- **Hide one service (fragile — avoid):** an individual service can only be identified by its LINE
+  service **channel id** (e.g. Schedule/create-event = `"1655112642"` real / `"1651805621"` beta,
+  hardcoded in enum `jg1.a$a.SCHEDULE` → `et1.s.g.SCHEDULE`). Channel ids are server-assigned and can
+  change, so a single-service patch can't be pinned to an APK version. Prefer the category-level gate.
+
+---
+
+## LINE Calendar vs Events vs Message scheduler — three distinct features
+
+Easy to conflate; they are separate features with separate entry points, gates, and destinations.
+
+**Calendar** (native LINE Calendar; strings `line_calendar_*`; feature gate interface `jp0.d`, impl
+`pp0.g`). Five in-messenger entry points, all removed by **"Hide LINE Calendar"**:
+
+| Surface | Class / anchor | Hide technique |
+|---|---|---|
+| Chats-tab header button | `az0.q.CALENDAR` added to list `fb8.b` in `gw1.f.<init>` | remove the `sget CALENDAR` + following `add(...)` pair |
+| Chat-room top toolbar | `ed1.d0.a`, `ed1.g1.CALENDAR_BUTTON` (two add-sites) via `ed1.s1.g(...)` | remove both `sget CALENDAR_BUTTON` + `g(...)` pairs |
+| `+` attach tile | `hg1.b` (see attach-menu section) | force `j()` false |
+| Slide-out chat-menu "Calendar" row | `d00.o` (holds `f11.b`), opens native Calendar Activity via `jp0.g` | force the row's `isVisible` ctor arg (`d00.a.e`) false |
+| Message long-press "Calendar" | provider `ne1.y0$c.a(Context,v01.a,j51.a,Z)Lj51/c;` (reads `j51.c.CALENDAR`) | force it to `return null` |
+
+**Events** (chat-menu row, `chatmenu_mainlist_button_events`) — **one** entry point only. A generic
+`d00.z` row built in `ChatHistoryMenuFragment` (~the `d00.z.<init>` block using string `0x7f150dfa`
++ icon `0x7f0807ce`), gated by the boolean field `Lyz/s4;->l:Z` (the sole UI read of that field).
+Opens a **server-configured web page** (`settings.e$c.D`), not the native calendar. Removed by
+**"Hide Events button"** — because `d00.z` is shared by other rows, patch at the build site: replace
+the `iget-boolean … s4.l` (matched by `fieldAccess(Lyz/s4;,"l")` + `literal(0x7f150dfa)`) with a
+`const 0` into the same register.
+
+**Message scheduler** ("send a message later"; `hg1.s`, strings `chat_scheduledmessages_*`) —
+unrelated to Calendar/Events; opens the scheduled-message composer (`yr1.a`/`xr1.b`). Not currently
+patched.
+
+### Chats-tab header button set (context for `az0.q`)
+
+The header button row (Chats tab, `com.linecorp.line.chattab.header.ChatTabHeaderStateImpl` =
+`gw1.f`) is built from the Kotlin enum **`az0.q`** (constants `AI_FRIEND, ALBUM, CALENDAR, OPEN_CHAT,
+PLUS_MENU` — names survive obfuscation). Buttons are `sget-object <az0.q const>` + `add(...)` into a
+`ListBuilder` `fb8.b`. A separate green-dot icon `Set` uses `fb8.j` and does **not** include
+`CALENDAR`. To hide a header button, remove its `sget`+`add` pair (see "Hide LINE Calendar" header
+row, and the sibling "Hide community button" which targets `OPEN_CHAT`).
+
+---
+
+## Shipped / proposed patches (this line of work)
+
+| Patch (name) | Package | Targets |
+|---|---|---|
+| Hide LINE Calendar | `line.chatheaderbuttons` | the 5 Calendar surfaces above |
+| Hide Events button | `line.hideevents` | the `d00.z` Events chat-menu row |
+| Hide Transfer button | `line.hidetransfer` | `hg1.k` (`+` Transfer/LINE Pay tile) |
+| Hide LINE GIFT button | `line.hidegift` | `hg1.h` (`+` LINE GIFT tile) |
+| Hide attach menu extra tools | `line.hideattachmenutools` | all server-driven `hg1.d` services |
+
+Each is an independent, `default = true`, user-facing `bytecodePatch` — one feature (or one feature's
+full set of entry points) per patch, matching the bundle's convention (cf. *Hide Wallet tab*,
+*Disable VOOM*). None needs an extension (all are fixed-value / instruction-level edits).


### PR DESCRIPTION
## What

Documentation-only. Captures the findings from this run of LINE patch work so future sessions don't have to re-derive them.

**New: `docs/line-patch-map.md`** (tracked reference), from decompiling LINE 26.11.0:
- **Chat "+" attach menu architecture** — static `hg1.r` tiles built inline in `gg1.e.r()` vs. the runtime/server-driven services all rendered by the single shared `hg1.d`; each item gated by its per-item `f()` / `j()` predicate.
- **Hiding recipes** — one static tile (neuter `j()`, anchor on the unique `fg1.a$b` type-constant read in its ctor) vs. the whole server-driven category (neuter the shared `hg1.d.f()` — stable, id-free) vs. why hiding a *single* server service is fragile (drifting channel ids).
- **Calendar vs Events vs Message scheduler** — three distinct features, with every Calendar entry point (header, toolbar, `+` tile, chat-menu row, long-press) and its class + anchor + hide technique.
- **Local build & verify without a PAT** — offline build with dummy creds, Morphe-CLI apply, and dexlib2 disassembly (no `baksmali` CLI ships).
- Table of the shipped/proposed patches and their packages (PRs #23–#25).

**`CLAUDE.md`** — folds in the reusable, version-independent bits: the offline build/verify recipe, the instruction-filter builders (`fieldAccess`/`methodCall`/`string`/`literal`/…), reading a matched instruction's registers, the UI-list-item hiding pattern, and a pointer to the new doc.

## Notes

- `docs:` commit → **no** release (only fix/feat/bump/perf/build do). No code or generated files touched.
- The obfuscated descriptors in the doc are 26.11.0-specific; the doc flags this and says to re-confirm them when bumping the pinned version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
