### PR TITLE
feat: hide "Unsend" for messages past the free unsend window

### DIFF
--- a/docs/line-premium-map.md
+++ b/docs/line-premium-map.md
@@ -182,3 +182,15 @@ doesn't hide them — a separate supplementary patch does:
   read here directly (one of the 7 non-`e13.a` `i1.W()` readers). Anchored via the unique promo
   string id `0x7f150bf8` → class `wi1.j4`; the `k2.a` first argument is forced false so the link
   handler stays null. Obfuscated `Lne1/k2;` drifts — re-verify on version bump.
+- **"Unsend" menu item for messages past the free window** — the biggest upsell ("Give yourself more
+  time to delete messages you sent") is reached only by tapping the long-press "Unsend" item on a
+  message older than the free window (~1h) but within the premium window (~7d). That item is built by
+  the candidate predicate `ne1.y0$y.a`, whose age gate `sentTime + window >= now` uses the **premium**
+  window (`Lj51/a;->p:I`) for premium-eligible chats — which is why the item (and its upsell) survives
+  for up to ~7 days. Past 7d the gate fails and the item is simply never added (no popup; the
+  `cantunsendafterperiod` string is dead). The patch rewrites that read to the **free** window
+  (`Lj51/a;->o:I`), so the item disappears past ~1h exactly like it does past 7d — no item, no upsell;
+  unsend within ~1h is unaffected. Anchored on `fieldAccess(Lj51/a;, p)` (the target read) + the
+  readable enum `Lj51/c;->PREMIUM_UNSEND_MESSAGE` (disambiguator; obfuscated `Lj51/a;`/`Lj51/c;`/`p`/`o`
+  drift — re-verify on version bump). Note: a premium subscriber applying the bundle also loses 1h–7d
+  unsend; for a non-premium user nothing is lost (those messages were never free-unsendable anyway).

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidepremiumunsend/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidepremiumunsend/Fingerprints.kt
@@ -1,6 +1,7 @@
 package app.andrewliang.patches.line.hidepremiumunsend
 
 import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.fieldAccess
 import app.morphe.patcher.literal
 import app.morphe.patcher.opcode
 import com.android.tools.smali.dexlib2.Opcode
@@ -32,5 +33,27 @@ internal object UnsendDiscreetlyButtonFingerprint : Fingerprint(
 internal object UnsendPromoLinkFingerprint : Fingerprint(
     filters = listOf(
         literal(0x7f150bf8),
+    ),
+)
+
+/**
+ * `ne1.y0$y.a(...)` — the candidate predicate that decides whether the long-press message menu
+ * shows an "Unsend" item. Its age gate is `sentTime + window >= now`, where `window` is the PREMIUM
+ * window (`Lj51/a;->p:I`, ~7 days) for premium-eligible chats, else the FREE window
+ * (`Lj51/a;->o:I`, ~1h). Using the premium window is why the item survives for messages up to ~7
+ * days and, when tapped, triggers the "Give yourself more time" upsell in `oe1.c0.a`; past ~7 days
+ * the gate fails and the item is never added.
+ *
+ * We match the premium-window read (`fieldAccess Lj51/a;->p`) as the instruction to rewrite, and
+ * disambiguate to this method via the readable enum member `Lj51/c;->PREMIUM_UNSEND_MESSAGE` (the
+ * obfuscated class descriptors drift; the enum member name is stable). Only `y0$y.a` accesses both.
+ * All three obfuscated descriptors here (`Lj51/a;`, `Lj51/c;`, fields `p`/`o`) must be re-verified
+ * on a LINE version bump.
+ */
+internal object UnsendMenuAgeGateFingerprint : Fingerprint(
+    returnType = "Lj51/c;",
+    filters = listOf(
+        fieldAccess(definingClass = "Lj51/a;", name = "p"),
+        fieldAccess(definingClass = "Lj51/c;", name = "PREMIUM_UNSEND_MESSAGE"),
     ),
 )

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidepremiumunsend/HidePremiumUnsendPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidepremiumunsend/HidePremiumUnsendPatch.kt
@@ -2,6 +2,7 @@ package app.andrewliang.patches.line.hidepremiumunsend
 
 import app.andrewliang.patches.shared.Constants.COMPATIBILITY_LINE
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.PatchException
 import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.Opcode
@@ -18,7 +19,9 @@ val hidePremiumUnsendPatch = bytecodePatch(
         "Premium\" (they read config directly instead of the market-availability flag): the " +
         "\"Unsend discreetly\" button in the unsend-message confirmation dialog, and the " +
         "\"How to unsend discreetly\" promotion link shown after unsending. The dialog keeps its " +
-        "ordinary \"Unsend\" and \"Close\" buttons.",
+        "ordinary \"Unsend\" and \"Close\" buttons. Also removes the \"Unsend\" long-press option " +
+        "for messages older than the free unsend window (~1h) so it no longer shows the \"Give " +
+        "yourself more time\" upgrade upsell — matching how messages past the premium window behave.",
     default = true,
 ) {
     compatibleWith(COMPATIBILITY_LINE)
@@ -80,5 +83,21 @@ val hidePremiumUnsendPatch = bytecodePatch(
             promoPatched = true
         }
         if (!promoPatched) throw PatchException("unsend promo-link k2.a call not found in ${promoClass.type}")
+
+        // --- 3) Remove the "Unsend" menu item for messages past the FREE unsend window ---
+        // ne1.y0$y.a adds the long-press "Unsend" item only if `sentTime + window >= now`. For
+        // premium-eligible chats `window` is the premium window (~7d, Lj51/a;->p), so the item
+        // survives for old messages and tapping it triggers the "Give yourself more time" upsell in
+        // oe1.c0.a. Rewrite that read to the FREE window (Lj51/a;->o, ~1h) so the gate uses the free
+        // window for all chats: the item then disappears past ~1h exactly like it already does past
+        // 7d — no item, no upsell. Within ~1h, unsend still works (the item is still added and its
+        // tap path is unchanged).
+        UnsendMenuAgeGateFingerprint.instructionMatches.first().let { premiumWindowRead ->
+            val read = premiumWindowRead.instruction as TwoRegisterInstruction
+            UnsendMenuAgeGateFingerprint.method.replaceInstruction(
+                premiumWindowRead.index,
+                "iget v${read.registerA}, v${read.registerB}, Lj51/a;->o:I",
+            )
+        }
     }
 }


### PR DESCRIPTION
## Summary

Extends the `Hide premium unsend upsells` patch so a sent message older than the **free** unsend window (~1h) no longer offers "Unsend" at all — matching how messages past the **premium** window (~7d) already behave — instead of showing the "Give yourself more time to delete messages you sent" upgrade upsell.

**Mechanism:** the long-press "Unsend" item is built by the candidate predicate `ne1.y0$y.a`, whose age gate is `sentTime + window >= now`. For premium-eligible chats `window` is the **premium** window (`Lj51/a;->p:I`, ~7d), which is why the item (and, on tap, its upsell in `oe1.c0.a`) survives for up to ~7 days. Past 7d the gate fails and the item is simply never added (no popup — the `cantunsendafterperiod` string is dead/unreferenced).

**Change:** rewrite that one read from the premium window to the **free** window (`Lj51/a;->p:I` → `Lj51/a;->o:I`), keeping the same registers. The gate then uses the free window for all chats, so the "Unsend" item disappears past ~1h exactly like it does past 7d — no item, no upsell. Unsend within ~1h is unaffected.

## Anchoring

`fieldAccess(Lj51/a;, p)` marks the target read; `fieldAccess(Lj51/c;, PREMIUM_UNSEND_MESSAGE)` — a **readable** enum member (class descriptors drift, member names are stable) — disambiguates to `ne1.y0$y.a` (only that method accesses both). The obfuscated `Lj51/a;`/`Lj51/c;`/`p`/`o` descriptors must be re-verified on a LINE version bump (documented).

## Verification

- Builds offline.
- Applied `--exclusive` against LINE 26.11.0 → "Writing 3 new classes" (adds `ne1/y0$y` alongside the existing `UnsendMessageLdsDialog` / `wi1.j4` edits).
- dexlib2 dump confirms **both** window reads in `ne1/y0$y.a` are now `Lj51/a;->o:I` (premium branch rewritten `p → o`, registers `v3, v12` preserved).
- Device check (pending): long-press a fresh (<~1h) message → "Unsend" present and works; long-press a message older than ~1h → **no "Unsend" option**, no upsell; rest of the long-press menu intact.

## Notes

- Trade-off: a **premium** subscriber applying the bundle also loses 1h–7d unsend; for a **non-premium** user nothing is lost (those messages were never free-unsendable — they only hit the upsell).
- Within ~1h the item is still typed `PREMIUM_UNSEND_MESSAGE`, so its label may read "Unsend from up to 7 days ago" on a fresh message — cosmetic only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
