### PR TITLE
feat: add Keep unsent messages patch

### DIFF
--- a/docs/line-patch-map.md
+++ b/docs/line-patch-map.md
@@ -307,7 +307,18 @@ forwarding and reactions keep working on the kept message.
 
 The guard is located **by instruction shape** (no-arg `Z` call → `move-result` → `if-eqz` → `goto`),
 and the `SQLiteDatabase` field reference is read out of the method's own bytecode — `i38.c`, its
-`h()`, and `g38.f3.b` are all obfuscated and drift.
+`h()`, and `g38.f3.b` are all obfuscated and drift. The two register reads are anchored rather than
+scanned blind: the message id must be a field of the same row object the guard reads its receiver
+off, and the `SQLiteDatabase` holder register must carry a `check-cast` to the field's own owner
+before the guard (this method has a *second* `SQLiteDatabase` read, `h38.t0.a`, that reuses the same
+register `v1` for a different type). Anything unresolvable — including a register spilling past
+`v15`, where `iget`/`invoke` operands stop fitting — throws rather than applying a half-patch.
+
+The insert is skipped when the row is **already** a tombstone (`type IN (27, 28, 38)` = what
+`i38.c.h()` covers). The injection sits ahead of the branch it flips, so it also runs where LINE's
+guard would have exited early — a redelivered unsend for a message tombstoned before the patch was
+installed, or one stripped by the offline `KEY_UNSENT_MESSAGE` path, which never reaches the guard
+at all. Both would otherwise draw the notice twice.
 
 ### Values that drift on a version bump
 
@@ -316,5 +327,5 @@ and the `SQLiteDatabase` field reference is read out of the method's own bytecod
 | `chat_history` table (`a68.a`) | only `id` constrained (PK + autoincrement); all other columns nullable; `IDX_SERVER_ID` is **non-unique** |
 | sort columns | `IDX_CHAT_ID_ID_CREATED_TIME` = `chat_id` (eq) + `created_time`, `id` (sort) → ordering follows `created_time` |
 | `created_time` | `DATE_STRING` → a **TEXT** column of epoch millis, so `+1` needs a `CAST` round-trip |
-| `i38.c` db values | `MESSAGE` = 1, `UNSENT` = 27, `UNSENT_NO_MARK` = 28, `SQUARE_UNSENT_MESSAGE` = 35, `UNSENT_SILENT` = 38 |
+| `i38.c` db values | `MESSAGE` = 1, `UNSENT` = 27, `UNSENT_NO_MARK` = 28, `SQUARE_UNSENT_MESSAGE` = 35, `UNSENT_SILENT` = 38 — the extension hardcodes 27 (the type it writes) and 27/28/38 (`i38.c.h()`'s set, the rows it refuses to annotate) |
 | `cb8.q7.NONE` | 0 (`attachement_type`) |

--- a/docs/line-patch-map.md
+++ b/docs/line-patch-map.md
@@ -329,3 +329,4 @@ at all. Both would otherwise draw the notice twice.
 | `created_time` | `DATE_STRING` → a **TEXT** column of epoch millis, so `+1` needs a `CAST` round-trip |
 | `i38.c` db values | `MESSAGE` = 1, `UNSENT` = 27, `UNSENT_NO_MARK` = 28, `SQUARE_UNSENT_MESSAGE` = 35, `UNSENT_SILENT` = 38 — the extension hardcodes 27 (the type it writes) and 27/28/38 (`i38.c.h()`'s set, the rows it refuses to annotate) |
 | `cb8.q7.NONE` | 0 (`attachement_type`) |
+| chat-list unread badge | `chat.message_count - chat.read_message_count` (`c23.d` columns, read in `z13.o`) — a stored counter pair, **not** a `count(*)` over `chat_history`, so the inserted placeholder cannot move it |

--- a/docs/line-patch-map.md
+++ b/docs/line-patch-map.md
@@ -165,6 +165,7 @@ row, and the sibling "Hide community button" which targets `OPEN_CHAT`).
 | Hide LINE GIFT button | `line.hidegift` | `hg1.h` (`+` LINE GIFT tile) |
 | Hide attach menu extra tools | `line.hideattachmenutools` | all server-driven `hg1.d` services |
 | Redirect LINE Pay | `line.disablepay` | `PayLaunchActivity` / `PayLiffActivity` onCreate (see below) |
+| Keep unsent messages | `line.keepunsent` | `g38.b0.invoke` — the unsend DB write (see below) |
 
 Each is an independent, `default = true`, user-facing `bytecodePatch` — one feature (or one feature's
 full set of entry points) per patch, matching the bundle's convention (cf. *Hide Wallet tab*,
@@ -236,3 +237,84 @@ LINE version routes there instead and the raw intent lacks a usable web url, reu
 resolver (anchor a fingerprint on the stable `"lpUsage"` / `"STANDALONE"` literals in
 `PayLiffActivity`, read the obfuscated `l5()`/`r7()` descriptors from the matches — don't hardcode
 `sv3.n`, which drifts).
+
+---
+
+## Message unsend (receive side) & the "Keep unsent messages" patch
+
+### How an incoming unsend reaches the database
+
+```
+OpType NOTIFIED_DESTROY_MESSAGE(65) / DESTROY_MESSAGE(64)   (Lcb8/ce;, Operation = Lcb8/de;)
+  ► e98.c1.b(...)  (someone else unsent)   /   e98.r  (3-line subclass: your own unsend)
+  ► the g38.b0 lambda, run inside a chat_history transaction
+```
+
+Both ops funnel through the **same** lambda, so one patch site covers your own unsends too.
+
+**LINE does not delete the row for 1:1/group chats.** `Lg38/b0;->invoke(Ljava/lang/Object;)Ljava/lang/Object;`
+(`smali_classes4/g38/b0.smali`) rewrites `chat_history.type` to an `i38.c.UNSENT*` variant and NULLs
+`content`, `parameter`, `attachement_type` and the location columns via `h38.h0` →
+`Lh38/b;->g(SQLiteDatabase, Li38/k;, Lh38/h0;)I`, then drops the message from the full-text-search
+index and deletes its `reactions` / `multiple_image_message_mapping` rows. All of it sits behind one
+guard:
+
+```smali
+    :cond_0
+    iget-object v6, v10, Li38/b;->g:Li38/c;   # v10 = the fetched row
+    iget-wide  v7, v10, Li38/b;->b:J          # message id (live at the guard)
+    invoke-virtual {v6}, Li38/c;->h()Z        # already an unsend tombstone?
+    move-result v6
+    if-eqz v6, :cond_1                        # no  -> destructive block
+    goto/16 :goto_c                           # yes -> skip, return the row unchanged
+```
+
+Forcing that register non-zero makes the unsend a **local no-op**. `Lg38/f3;` (the lambda's
+parameter, `v1`) carries the transaction's `SQLiteDatabase` in field `b`.
+
+**OpenChat/Square is a different path and genuinely deletes**: `SquareEventType.NOTIFIED_DESTROY_MESSAGE(5)`
+→ `fp5.i` → `Lg38/q0;->m(Ljava/lang/String;Ljava/util/Set;)V` → `g38.f3.c(Set)` →
+`DELETE FROM chat_history WHERE id IN(...)`. Not covered by the patch.
+
+A third path exists for messages unsent while offline: full sync / message-box restore reads
+`z58.b.c.KEY_UNSENT_MESSAGE` / `KEY_SILENTLY_UNSENT` from `contentMetadata` (`g38.q0`, `g38.x2`) and
+stores the row already stripped. Nothing local to keep there.
+
+### How the placeholder is rendered
+
+`chat_history.type` → content model → text, four hops:
+
+| Hop | Descriptor |
+|---|---|
+| cursor → content model | `Lh38/t;->e(Lcb8/q7;Ljp/naver/line/android/util/j;Lz58/b;)Li38/g;` — `UNSENT` builds `Li38/g$s$h0;` from `from_mid` |
+| content → UI model | `Lm11/b;->k(Li38/g$s;)Ll11/h;` → `Ll11/h$h0;` |
+| UI model → text | `Lcl1/c;->a(Landroid/content/Context;Ll11/h;Lo21/a;)Ljava/lang/CharSequence;` |
+| bubble decoration | `Lwi1/j4;->K0(...)` — appends the "How to unsend discreetly" link on *your own* unsends (suppressed by *Hide premium unsend upsells*) |
+
+Strings: `chathistory_message_format_unsent_receiver` (`0x7f150d65`, "%1$s unsent a message.") and
+`chathistory_message_format_unsent_sender` (`0x7f150d66`, "You unsent a message.") — chosen by
+comparing `from_mid` against your own mid.
+
+`Lh38/x;` (query builder) filters `UNSENT_SILENT` out of chat history entirely
+(`type NOT IN (...)`), which is how LYP "unsend discreetly" hides a row it still stores.
+
+### What the patch does
+
+Skips the guard, then inserts its **own** `type = UNSENT` row so the notice still appears — see
+`app/andrewliang/extension/KeepUnsentMessages.java`. Keeping the original row untouched (rather than
+copying it and letting LINE tombstone the original) preserves its real `server_id`, so reply-jump,
+forwarding and reactions keep working on the kept message.
+
+The guard is located **by instruction shape** (no-arg `Z` call → `move-result` → `if-eqz` → `goto`),
+and the `SQLiteDatabase` field reference is read out of the method's own bytecode — `i38.c`, its
+`h()`, and `g38.f3.b` are all obfuscated and drift.
+
+### Values that drift on a version bump
+
+| Thing | 26.11.0 |
+|---|---|
+| `chat_history` table (`a68.a`) | only `id` constrained (PK + autoincrement); all other columns nullable; `IDX_SERVER_ID` is **non-unique** |
+| sort columns | `IDX_CHAT_ID_ID_CREATED_TIME` = `chat_id` (eq) + `created_time`, `id` (sort) → ordering follows `created_time` |
+| `created_time` | `DATE_STRING` → a **TEXT** column of epoch millis, so `+1` needs a `CAST` round-trip |
+| `i38.c` db values | `MESSAGE` = 1, `UNSENT` = 27, `UNSENT_NO_MARK` = 28, `SQUARE_UNSENT_MESSAGE` = 35, `UNSENT_SILENT` = 38 |
+| `cb8.q7.NONE` | 0 (`attachement_type`) |

--- a/extensions/extension/src/main/java/app/andrewliang/extension/KeepUnsentMessages.java
+++ b/extensions/extension/src/main/java/app/andrewliang/extension/KeepUnsentMessages.java
@@ -28,6 +28,13 @@ public final class KeepUnsentMessages {
     /** {@code i38.c.UNSENT} db value — the "this message was unsent" chat_history.type. */
     private static final int TYPE_UNSENT = 27;
 
+    /**
+     * The tombstone types, i.e. exactly what {@code i38.c.h()} — the guard the patch skips —
+     * returns true for: {@code UNSENT}(27), {@code UNSENT_NO_MARK}(28), {@code UNSENT_SILENT}(38).
+     * A row of one of these types already <em>is</em> an "unsent a message" notice.
+     */
+    private static final String TYPES_ALREADY_UNSENT = "27, 28, 38";
+
     /** {@code cb8.q7.NONE} db value, matching what LINE's own unsend writes. */
     private static final int ATTACHMENT_NONE = 0;
 
@@ -49,6 +56,14 @@ public final class KeepUnsentMessages {
      * <p>{@code status}, {@code read_count} and {@code sent_count} are inherited so the
      * placeholder cannot skew unread counts. {@code content} is left NULL deliberately — for this
      * type the renderer ignores it and builds the text from {@code from_mid}.
+     *
+     * <p>Rows that are already tombstones are skipped. The patch injects ahead of the branch it
+     * flips, so this runs even when LINE's own guard would have exited early — a redelivered
+     * unsend for a message tombstoned before the patch was installed, or one stripped by the
+     * offline {@code KEY_UNSENT_MESSAGE} sync path, which never reaches that guard at all.
+     * Annotating either would draw the notice twice. Checking the row's type here is the same
+     * question the guard asks, answered from the database rather than from a register the
+     * injection has already overwritten.
      */
     private static final String INSERT_PLACEHOLDER =
             "INSERT INTO chat_history"
@@ -61,6 +76,7 @@ public final class KeepUnsentMessages {
                     + " WHERE (o.server_id = ? OR o.id = ?)"
                     + " AND o.server_id IS NOT NULL"
                     + " AND o.created_time IS NOT NULL"
+                    + " AND o.type NOT IN (" + TYPES_ALREADY_UNSENT + ")"
                     + " AND NOT EXISTS ("
                     + "  SELECT 1 FROM chat_history x WHERE x.server_id = o.server_id || ?)"
                     + " LIMIT 1";

--- a/extensions/extension/src/main/java/app/andrewliang/extension/KeepUnsentMessages.java
+++ b/extensions/extension/src/main/java/app/andrewliang/extension/KeepUnsentMessages.java
@@ -1,0 +1,93 @@
+package app.andrewliang.extension;
+
+import android.database.sqlite.SQLiteDatabase;
+import android.util.Log;
+
+/**
+ * Helper for the "Keep unsent messages" patch.
+ *
+ * <p>The patch makes LINE skip the database work it normally does when a message is unsent in a
+ * 1:1 or group chat, so the row survives untouched — text, media, reactions and its search-index
+ * entry all intact. Nothing then marks the message as recalled, so we add that marker ourselves:
+ * a second, synthetic {@code chat_history} row of type {@code i38.c.UNSENT}.
+ *
+ * <p>That type is all LINE's renderer needs. It maps the row to the {@code i38.g.s.h0} content
+ * model, which resolves to {@code chathistory_message_format_unsent_receiver}
+ * ("%1$s unsent a message.") — or the "You unsent a message." variant when {@code from_mid} is
+ * your own account. Copying {@code from_mid} from the original row therefore gives correct sender
+ * naming and free localisation, with no injected strings.
+ *
+ * <p>Best-effort: any failure is swallowed, leaving the kept message in place without a notice.
+ */
+public final class KeepUnsentMessages {
+
+    private KeepUnsentMessages() {}
+
+    private static final String TAG = "AndrewKeepUnsent";
+
+    /** {@code i38.c.UNSENT} db value — the "this message was unsent" chat_history.type. */
+    private static final int TYPE_UNSENT = 27;
+
+    /** {@code cb8.q7.NONE} db value, matching what LINE's own unsend writes. */
+    private static final int ATTACHMENT_NONE = 0;
+
+    /**
+     * Suffix appended to the original {@code server_id} to form the placeholder's own id. Keeps
+     * the synthetic row distinguishable from real server rows and makes the insert idempotent.
+     */
+    private static final String MARK = "_unsent";
+
+    /**
+     * Copies the identifying columns of the unsent message into a new tombstone row.
+     *
+     * <p>{@code created_time} is a TEXT column holding epoch millis, so the +1 that orders the
+     * placeholder directly below its message needs a cast round-trip. Ordering follows
+     * {@code created_time} (the {@code IDX_CHAT_ID_ID_CREATED_TIME} sort columns), so the notice
+     * lands under the message rather than at the end of the conversation; a one millisecond
+     * offset is invisible at the minute precision the UI displays.
+     *
+     * <p>{@code status}, {@code read_count} and {@code sent_count} are inherited so the
+     * placeholder cannot skew unread counts. {@code content} is left NULL deliberately — for this
+     * type the renderer ignores it and builds the text from {@code from_mid}.
+     */
+    private static final String INSERT_PLACEHOLDER =
+            "INSERT INTO chat_history"
+                    + " (server_id, type, chat_id, from_mid, created_time, delivered_time,"
+                    + " status, read_count, sent_count, attachement_type)"
+                    + " SELECT o.server_id || ?, ?, o.chat_id, o.from_mid,"
+                    + " CAST(CAST(o.created_time AS INTEGER) + 1 AS TEXT), o.delivered_time,"
+                    + " o.status, o.read_count, o.sent_count, ?"
+                    + " FROM chat_history o"
+                    + " WHERE (o.server_id = ? OR o.id = ?)"
+                    + " AND o.server_id IS NOT NULL"
+                    + " AND o.created_time IS NOT NULL"
+                    + " AND NOT EXISTS ("
+                    + "  SELECT 1 FROM chat_history x WHERE x.server_id = o.server_id || ?)"
+                    + " LIMIT 1";
+
+    /**
+     * Best-effort: add the "unsent a message" notice under the message we just kept.
+     *
+     * @param db        the open chat database, inside LINE's own unsend transaction.
+     * @param messageId the unsent message's id. The caller reads whichever of the row's two long
+     *                  ids is already loaded at the patch site, so this may be either the local
+     *                  {@code chat_history.id} or the {@code server_id}; the statement matches on
+     *                  either. Local ids are small and server ids are large, so the two id spaces
+     *                  do not realistically overlap, and {@code LIMIT 1} bounds it regardless.
+     */
+    public static void insertPlaceholder(SQLiteDatabase db, long messageId) {
+        if (db == null) return;
+        try {
+            db.execSQL(INSERT_PLACEHOLDER, new Object[] {
+                    MARK,
+                    Integer.valueOf(TYPE_UNSENT),
+                    Integer.valueOf(ATTACHMENT_NONE),
+                    String.valueOf(messageId),
+                    Long.valueOf(messageId),
+                    MARK,
+            });
+        } catch (Throwable t) {
+            Log.w(TAG, "Could not add the unsent notice; keeping the message without one.", t);
+        }
+    }
+}

--- a/extensions/extension/src/main/java/app/andrewliang/extension/KeepUnsentMessages.java
+++ b/extensions/extension/src/main/java/app/andrewliang/extension/KeepUnsentMessages.java
@@ -53,9 +53,19 @@ public final class KeepUnsentMessages {
      * lands under the message rather than at the end of the conversation; a one millisecond
      * offset is invisible at the minute precision the UI displays.
      *
-     * <p>{@code status}, {@code read_count} and {@code sent_count} are inherited so the
-     * placeholder cannot skew unread counts. {@code content} is left NULL deliberately — for this
-     * type the renderer ignores it and builds the text from {@code from_mid}.
+     * <p>{@code status}, {@code read_count} and {@code sent_count} are inherited so the notice
+     * carries the same read receipt as the message it annotates. These are per-message columns and
+     * are <em>not</em> what the chat list's unread badge is made of: that is
+     * {@code chat.message_count - chat.read_message_count}, two stored counters on the {@code chat}
+     * row (see {@code z13.o}), which only LINE's own insert path maintains and this patch never
+     * writes. So the badge is safe regardless of what is copied here — but it also means
+     * {@code message_count} now sits one behind the real row count per kept message. Harmless
+     * while nothing recomputes it from {@code chat_history}; {@code g38.g2.j(chatId)} is a
+     * per-chat {@code count(*)} of that shape, with no caller found that writes it back.
+     * Worth re-checking on a version bump.
+     *
+     * <p>{@code content} is left NULL deliberately — for this type the renderer ignores it and
+     * builds the text from {@code from_mid}.
      *
      * <p>Rows that are already tombstones are skipped. The patch injects ahead of the branch it
      * flips, so this runs even when LINE's own guard would have exited early — a redelivered

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/keepunsent/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/keepunsent/Fingerprints.kt
@@ -1,0 +1,35 @@
+package app.andrewliang.patches.line.keepunsent
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.string
+
+/**
+ * The lambda that applies an incoming unsend to the local database — obfuscated
+ * `g38.b0.invoke(Object)`, run inside a `chat_history` transaction by the
+ * `NOTIFIED_DESTROY_MESSAGE`(65) / `DESTROY_MESSAGE`(64) op handlers (`e98.c1` / `e98.r`).
+ *
+ * LINE does NOT delete the row here: it rewrites `chat_history.type` to an `i38.c.UNSENT*`
+ * variant and NULLs `content`, `parameter`, `attachement_type` and the location columns, then
+ * drops the message from the full-text-search index and deletes its `reactions` and
+ * `multiple_image_message_mapping` rows. Every one of those writes sits behind a single
+ * "is this row already an unsend tombstone?" guard (`i38.c.h()`), which is what the patch flips.
+ *
+ * Anchored on the four SQL table/where-clause string literals the method uses for its cleanup
+ * deletes. They are non-obfuscated, appear in this exact program order, and this cluster of four
+ * is unique to this one method across the whole APK (every other class that mentions
+ * `multiple_image_message_mapping` or `local_message_id = ?` is missing at least one of the rest).
+ * The `Object invoke(Object)` signature additionally pins it to the Kotlin lambda itself.
+ *
+ * The strings are only used to *locate* the method — the guard is then found by instruction shape,
+ * since `i38.c` and its `h()` are obfuscated and drift between LINE versions.
+ */
+internal object UnsendMessageDbWriteFingerprint : Fingerprint(
+    returnType = "Ljava/lang/Object;",
+    parameters = listOf("Ljava/lang/Object;"),
+    filters = listOf(
+        string("reactions"),
+        string("server_message_id=?"),
+        string("multiple_image_message_mapping"),
+        string("local_message_id = ?"),
+    ),
+)

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/keepunsent/KeepUnsentMessagesPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/keepunsent/KeepUnsentMessagesPatch.kt
@@ -1,0 +1,121 @@
+package app.andrewliang.patches.line.keepunsent
+
+import app.andrewliang.patches.shared.Constants.COMPATIBILITY_LINE
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.PatchException
+import app.morphe.patcher.patch.bytecodePatch
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+
+private const val SQLITE_DATABASE = "Landroid/database/sqlite/SQLiteDatabase;"
+private const val EXTENSION = "Lapp/andrewliang/extension/KeepUnsentMessages;"
+private const val INSERT_PLACEHOLDER = "insertPlaceholder(${SQLITE_DATABASE}J)V"
+
+/** Highest register addressable by the 4-bit operands of `invoke-*` (35c) and `iget-*` (22c). */
+private const val MAX_NIBBLE_REGISTER = 15
+
+@Suppress("unused")
+val keepUnsentMessagesPatch = bytecodePatch(
+    name = "Keep unsent messages",
+    description = "Keeps messages that were unsent in 1:1 and group chats on your device " +
+        "instead of destroying them, and shows the usual \"unsent a message\" notice directly " +
+        "below the message it kept. Doesn't apply to OpenChat.",
+    default = true,
+) {
+    compatibleWith(COMPATIBILITY_LINE)
+
+    extendWith("extensions/extension.mpe")
+
+    // An incoming unsend is applied by the g38.b0 lambda, which rewrites chat_history.type to
+    // i38.c.UNSENT and NULLs content/parameter/attachement_type/locations, then drops the row from
+    // the search index and deletes its reactions + multiple_image_message_mapping rows. All of
+    // that hangs off one guard:
+    //
+    //     invoke-virtual {v6}, Li38/c;->h()Z   # already an unsend tombstone?
+    //     move-result v6
+    //     if-eqz v6, :cond_1                   # no  -> run the destructive block
+    //     goto/16 :goto_c                      # yes -> skip it all, return the row unchanged
+    //
+    // Forcing the guard register non-zero always takes the "skip" branch, so the message survives
+    // intact — text, media, reactions and its search-index entry. LINE never learns it was
+    // recalled, so nothing marks it: we insert our own i38.c.UNSENT (dbValue 27) row just below
+    // it, which LINE's stock renderer draws as "<name> unsent a message." with correct sender
+    // naming and localisation. See the extension for the INSERT.
+    //
+    // The guard is located by instruction shape rather than by name: i38.c and its h() are
+    // obfuscated and drift. The SQLiteDatabase field read (g38.f3.b) is likewise taken from the
+    // method's own bytecode instead of being hardcoded.
+    execute {
+        val method = UnsendMessageDbWriteFingerprint.method
+        val instructions = method.implementation!!.instructions.toList()
+
+        // The guard: a no-arg boolean call whose result is immediately branched on, where the
+        // fall-through is an unconditional jump (the "already unsent, skip everything" exit).
+        // No other call in this method has that shape.
+        val guardIndex = instructions.indices.firstOrNull { index ->
+            val reference = (instructions[index] as? ReferenceInstruction)?.reference as? MethodReference
+            instructions[index].opcode == Opcode.INVOKE_VIRTUAL &&
+                reference?.returnType == "Z" &&
+                reference.parameterTypes.isEmpty() &&
+                instructions.getOrNull(index + 1)?.opcode == Opcode.MOVE_RESULT &&
+                instructions.getOrNull(index + 2)?.opcode == Opcode.IF_EQZ &&
+                instructions.getOrNull(index + 3)?.opcode in
+                setOf(Opcode.GOTO, Opcode.GOTO_16, Opcode.GOTO_32)
+        } ?: throw PatchException("unsend: already-unsent guard not found in ${method.definingClass}")
+
+        val guardRegister = (instructions[guardIndex + 1] as OneRegisterInstruction).registerA
+
+        // The message id, loaded from the fetched row a few instructions above the guard and still
+        // live there. Which of i38.b's two long fields this is (local id vs server message id)
+        // doesn't matter — the extension's WHERE clause accepts either.
+        val messageIdRegister = (guardIndex - 1 downTo 0)
+            .firstOrNull { instructions[it].opcode == Opcode.IGET_WIDE }
+            ?.let { (instructions[it] as TwoRegisterInstruction).registerA }
+            ?: throw PatchException("unsend: message id read not found in ${method.definingClass}")
+
+        // The transaction's SQLiteDatabase, read off the g38.f3 receiver inside the block we skip.
+        // Reuse that exact field reference and holder register rather than hardcoding g38.f3.b.
+        val databaseRead = (guardIndex until instructions.size).firstNotNullOfOrNull { index ->
+            val reference = (instructions[index] as? ReferenceInstruction)?.reference as? FieldReference
+            if (instructions[index].opcode == Opcode.IGET_OBJECT && reference?.type == SQLITE_DATABASE) {
+                reference to (instructions[index] as TwoRegisterInstruction).registerB
+            } else {
+                null
+            }
+        }
+        val (databaseField, databaseHolderRegister) = databaseRead
+            ?: throw PatchException("unsend: SQLiteDatabase field read not found in ${method.definingClass}")
+
+        // v0-v15 only for iget-object (22c) and invoke-static (35c). On 26.11.0 these are v1/v6/v7,
+        // but if a future version spills them we still keep the message and just skip the notice
+        // rather than emitting instructions that silently assemble to the wrong registers.
+        val registersAddressable = maxOf(
+            guardRegister,
+            databaseHolderRegister,
+            messageIdRegister + 1,
+        ) <= MAX_NIBBLE_REGISTER
+
+        val addPlaceholder = if (registersAddressable) {
+            """
+                iget-object v$guardRegister, v$databaseHolderRegister, ${databaseField.definingClass}->${databaseField.name}:${databaseField.type}
+                invoke-static {v$guardRegister, v$messageIdRegister, v${messageIdRegister + 1}}, $EXTENSION->$INSERT_PLACEHOLDER
+            """
+        } else {
+            ""
+        }
+
+        // The guard register is dead here (the skipped block reassigns it immediately), so it is
+        // free to borrow for the database reference before being forced to 1.
+        method.addInstructions(
+            guardIndex + 2,
+            """
+                $addPlaceholder
+                const/16 v$guardRegister, 0x1
+            """,
+        )
+    }
+}

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/keepunsent/KeepUnsentMessagesPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/keepunsent/KeepUnsentMessagesPatch.kt
@@ -5,11 +5,13 @@ import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.patch.PatchException
 import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.reference.FieldReference
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import com.android.tools.smali.dexlib2.iface.reference.TypeReference
 
 private const val SQLITE_DATABASE = "Landroid/database/sqlite/SQLiteDatabase;"
 private const val EXTENSION = "Lapp/andrewliang/extension/KeepUnsentMessages;"
@@ -69,23 +71,56 @@ val keepUnsentMessagesPatch = bytecodePatch(
 
         val guardRegister = (instructions[guardIndex + 1] as OneRegisterInstruction).registerA
 
-        // The message id, loaded from the fetched row a few instructions above the guard and still
-        // live there. Which of i38.b's two long fields this is (local id vs server message id)
-        // doesn't matter — the extension's WHERE clause accepts either.
-        val messageIdRegister = (guardIndex - 1 downTo 0)
-            .firstOrNull { instructions[it].opcode == Opcode.IGET_WIDE }
+        // The fetched row (i38.b), taken from whatever the guard reads its receiver off. Anchoring
+        // on it keeps the id search below from wandering: an `iget-wide` that reads the same object
+        // the guard does is the row's id, and it sits in the same straight-line stretch, so the
+        // register it writes is live where we inject.
+        val guardReceiverRegister = (instructions[guardIndex] as FiveRegisterInstruction).registerC
+        val rowReadIndex = (guardIndex - 1 downTo 0).firstOrNull { index ->
+            instructions[index].opcode == Opcode.IGET_OBJECT &&
+                (instructions[index] as TwoRegisterInstruction).registerA == guardReceiverRegister
+        } ?: throw PatchException("unsend: guard receiver read not found in ${method.definingClass}")
+        val rowRegister = (instructions[rowReadIndex] as TwoRegisterInstruction).registerB
+
+        // The message id, read off that row between it being loaded and the guard. Which of i38.b's
+        // longs this is (local id vs server message id) doesn't matter — the extension's WHERE
+        // clause accepts either. On 26.11.0 it is `b`, the server id.
+        val messageIdRegister = ((rowReadIndex + 1) until guardIndex)
+            .firstOrNull { index ->
+                instructions[index].opcode == Opcode.IGET_WIDE &&
+                    (instructions[index] as TwoRegisterInstruction).registerB == rowRegister
+            }
             ?.let { (instructions[it] as TwoRegisterInstruction).registerA }
             ?: throw PatchException("unsend: message id read not found in ${method.definingClass}")
 
+        // Registers whose type is proven before the guard. The lambda's parameter is `check-cast`ed
+        // at the method head, and that cast dominates our injection point, so such a register still
+        // holds that type where we inject — which a field read taken from inside the skipped block
+        // does not by itself establish.
+        val castRegisters = (0 until guardIndex).mapNotNull { index ->
+            val instruction = instructions[index]
+            if (instruction.opcode != Opcode.CHECK_CAST) return@mapNotNull null
+            val type = ((instruction as ReferenceInstruction).reference as? TypeReference)?.type
+                ?: return@mapNotNull null
+            (instruction as OneRegisterInstruction).registerA to type
+        }.toMap()
+
         // The transaction's SQLiteDatabase, read off the g38.f3 receiver inside the block we skip.
         // Reuse that exact field reference and holder register rather than hardcoding g38.f3.b.
+        // The field reference travels safely (it is position-independent); the register number only
+        // does if the register provably holds the field's owner at the injection point, so require
+        // a dominating cast. That also rejects the second SQLiteDatabase read further down this
+        // method (h38.t0.a), which reuses the same register for a different type.
         val databaseRead = (guardIndex until instructions.size).firstNotNullOfOrNull { index ->
             val reference = (instructions[index] as? ReferenceInstruction)?.reference as? FieldReference
-            if (instructions[index].opcode == Opcode.IGET_OBJECT && reference?.type == SQLITE_DATABASE) {
-                reference to (instructions[index] as TwoRegisterInstruction).registerB
-            } else {
-                null
+            if (instructions[index].opcode != Opcode.IGET_OBJECT || reference?.type != SQLITE_DATABASE) {
+                return@firstNotNullOfOrNull null
             }
+            val holderRegister = (instructions[index] as TwoRegisterInstruction).registerB
+            if (castRegisters[holderRegister] != reference.definingClass) {
+                return@firstNotNullOfOrNull null
+            }
+            reference to holderRegister
         }
         val (databaseField, databaseHolderRegister) = databaseRead
             ?: throw PatchException("unsend: SQLiteDatabase field read not found in ${method.definingClass}")

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/keepunsent/KeepUnsentMessagesPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/keepunsent/KeepUnsentMessagesPatch.kt
@@ -90,22 +90,21 @@ val keepUnsentMessagesPatch = bytecodePatch(
         val (databaseField, databaseHolderRegister) = databaseRead
             ?: throw PatchException("unsend: SQLiteDatabase field read not found in ${method.definingClass}")
 
-        // v0-v15 only for iget-object (22c) and invoke-static (35c). On 26.11.0 these are v1/v6/v7,
-        // but if a future version spills them we still keep the message and just skip the notice
-        // rather than emitting instructions that silently assemble to the wrong registers.
-        val registersAddressable = maxOf(
+        // v0-v15 only for iget-object (22c) and invoke-static (35c); referencing v16+ there is
+        // silently mis-assembled. On 26.11.0 these are v1/v6/v7, but the method is `.locals 29`,
+        // so a future version could spill them. Fail loudly rather than keeping messages with no
+        // notice: an unmarked kept message is indistinguishable from one that was never unsent.
+        val highestRegister = maxOf(
             guardRegister,
             databaseHolderRegister,
             messageIdRegister + 1,
-        ) <= MAX_NIBBLE_REGISTER
-
-        val addPlaceholder = if (registersAddressable) {
-            """
-                iget-object v$guardRegister, v$databaseHolderRegister, ${databaseField.definingClass}->${databaseField.name}:${databaseField.type}
-                invoke-static {v$guardRegister, v$messageIdRegister, v${messageIdRegister + 1}}, $EXTENSION->$INSERT_PLACEHOLDER
-            """
-        } else {
-            ""
+        )
+        if (highestRegister > MAX_NIBBLE_REGISTER) {
+            throw PatchException(
+                "unsend: guard/database/message-id registers spilled past " +
+                    "v$MAX_NIBBLE_REGISTER (highest is v$highestRegister) " +
+                    "in ${method.definingClass}",
+            )
         }
 
         // The guard register is dead here (the skipped block reassigns it immediately), so it is
@@ -113,7 +112,8 @@ val keepUnsentMessagesPatch = bytecodePatch(
         method.addInstructions(
             guardIndex + 2,
             """
-                $addPlaceholder
+                iget-object v$guardRegister, v$databaseHolderRegister, ${databaseField.definingClass}->${databaseField.name}:${databaseField.type}
+                invoke-static {v$guardRegister, v$messageIdRegister, v${messageIdRegister + 1}}, $EXTENSION->$INSERT_PLACEHOLDER
                 const/16 v$guardRegister, 0x1
             """,
         )


### PR DESCRIPTION
Keeps messages that were unsent in 1:1 and group chats on the device instead of destroying them, with LINE's usual "unsent a message" notice shown directly below the message it kept.

```
 Alice
 ╭──────────────────────────────╮
 │ Hey ignore that, wrong chat  │  14:32
 ╰──────────────────────────────╯
 ╭──────────────────────────────╮
 │ Alice unsent a message.      │  14:32
 ╰──────────────────────────────╯
```

## How it works

An incoming unsend (`NOTIFIED_DESTROY_MESSAGE` / `DESTROY_MESSAGE`) is applied by the `g38.b0` lambda, which **does not delete the row** for 1:1/group chats: it rewrites `chat_history.type` to `i38.c.UNSENT` and NULLs `content`, `parameter`, `attachement_type` and the location columns, then drops the message from the search index and deletes its `reactions` / `multiple_image_message_mapping` rows.

All of that sits behind a single "is this already a tombstone?" guard, so forcing that guard's register non-zero makes the whole unsend a **local no-op** — text, media, reactions and the search-index entry all survive:

```
17 invoke-virtual {v6}  Li38/c;->h
18 move-result v6
19 iget-object v6, v1  Lg38/f3;->b:...SQLiteDatabase;   <- injected
20 invoke-static {v6, v7, v8}  KeepUnsentMessages;->insertPlaceholder
21 const/16 v6 #1                                        <- injected
22 if-eqz v6            (original, now never taken)
23 goto/16              (original skip path)
```

LINE then never learns the message was recalled, so nothing marks it. The extension inserts its **own** `i38.c.UNSENT` (dbValue 27) row at `created_time + 1`, which LINE's stock renderer draws as the usual notice — correct sender naming and localisation, no injected strings.

Keeping the original row untouched (rather than copying it and letting LINE tombstone the original) preserves its real `server_id`, so reply-jump, forwarding and reactions keep working on the kept message.

Both directions are covered: your own unsends arrive through the same lambda.

### Drift resistance

`i38.c`, its `h()` and `g38.f3.b` are all obfuscated and drift between versions, so nothing is hardcoded. The guard is located **by instruction shape**, and both register reads are anchored rather than scanned blind:

- the message id must be a field of **the same row object** the guard reads its receiver off, searched only between that read and the guard — so it can't drift onto an unrelated `long`, and it's provably live where we inject;
- the `SQLiteDatabase` holder register must carry a `check-cast` to the field's own owner **before** the guard. The field reference is position-independent and travels safely; the register number only does if its type is established at the injection point. This also rejects the second `SQLiteDatabase` read in this method (`h38.t0.a`), which reuses the same register `v1` for a different type.

Anything unresolvable — including a register spilling past `v15`, where `iget`/`invoke` operands stop fitting — throws rather than applying half the patch. A kept message with no notice is indistinguishable from one that was never unsent, so that case fails loudly and lands in `failedPatches` instead of shipping silently.

The insert is also skipped when the row is **already** a tombstone (`type IN (27, 28, 38)`, exactly what `i38.c.h()` covers). The injection sits ahead of the branch it flips, so it runs even where LINE's guard would have exited early — a redelivered unsend for a message tombstoned before the patch was installed, or one stripped by the offline `KEY_UNSENT_MESSAGE` path, which never reaches that guard at all. Both would otherwise draw the notice twice.

## Verification

**Static.** Builds clean; patch registers and applies (`Applied: Keep unsent messages`), and re-confirmed in a **full-bundle** apply alongside all 19 other patches (20 applied, 0 failed). Disassembled the patched dex — injection lands exactly as designed, with the original branch pair and the whole destructive block untouched.

**SQL.** Ran the extension's statement — extracted from the source and confirmed byte-equal to the string in the patched APK — against a real SQLite replica of LINE's `chat_history` schema: the placeholder sorts between the unsent message and the next message (not at the end of the chat), is idempotent on redelivery, matches whether the id passed in is the local or the server id, inherits `status`/`read_count`/`sent_count` with NULL `content`, and leaves rows that are already tombstones alone.

**On device (LINE 26.11.0, full bundle).**

- Unsent message survives with its content intact.
- Notice renders **live** in the chatroom, directly under the kept message — no reopen needed, and it does not land at the end of the conversation.
- Your own unsends behave identically and render the "You unsent a message." variant.
- Media survives: images on kept messages are still downloadable.

## Known gaps (documented)

- **OpenChat / Square is not covered** — a separate handler that genuinely `DELETE`s the row.
- Messages unsent **while you were fully offline** arrive already stripped from the server (the `KEY_UNSENT_MESSAGE` metadata sync path), so there is nothing local to keep.
- **The sender's push notification still disappears.** LINE cancels the shade notification on the destroy op, in a path this patch doesn't touch. The message and its notice are both in the chatroom, so this only costs a notification-shade entry for content you can still read.
- **Kept media may not stay downloadable forever.** The row and its obs hash are local, but the media itself is fetched from LINE's servers on demand, and a sender who unsent likely gets their copy purged server-side eventually. Anything already cached on the device stays. Not verified — a plausible limitation rather than a measured one.
- **Chat-list preview may lag.** Taking the guard's skip path also skips LINE's chat-summary update (`g38.q0.l` / `q0.C`), which stock LINE is right to skip on that path — nothing changed — but we did insert a row. The chatroom renders live regardless; the chat-list preview row is the one surface that could stay stale until the next message arrives. Cosmetic; fixable in one instruction if it ever matters.
- Kept messages **remain in the full-text-search index**, so an unsent message is still findable in search. Intended — the whole point is that the content survives.

`docs/line-patch-map.md` gains a section on the unsend receive path, the render path, and the values that drift on a version bump (`i38.c` db values, the `chat_history` sort columns, `created_time` being TEXT, and the chat-list unread badge being a stored counter pair rather than a `count(*)` over `chat_history`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
