### PR TITLE
docs: embed the star history chart in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,12 @@ of **Standard** install (which re-signs the APK).
 
 ## ⭐ Star history
 
-<a href="https://www.star-history.com/?repos=andrewliang25%2Fmorphe-patches&type=date">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=andrewliang25/morphe-patches&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=andrewliang25/morphe-patches&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=andrewliang25/morphe-patches&type=Date" width="600" />
-  </picture>
+<a href="https://www.star-history.com/?repos=andrewliang25%2Fmorphe-patches&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=andrewliang25/morphe-patches&type=date&theme=dark&legend=top-left&sealed_token=wmq23aagupD99LpnPmnuBYZf96xmHbGhV8iIcXKvUVhQnTCNUVF2JpgGdwyfP6URWdMcuGaz2rvT6i8TBlXiM87iM5CdppJY49yKQ67L9OhuUvXrtitmqnJlVaqgY9K2i95l4t7KmBAePGbdfm-hNI04kIwfLLAy-fDLGUbOQVnVQUqEeSevgf7E4s7w" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=andrewliang25/morphe-patches&type=date&legend=top-left&sealed_token=wmq23aagupD99LpnPmnuBYZf96xmHbGhV8iIcXKvUVhQnTCNUVF2JpgGdwyfP6URWdMcuGaz2rvT6i8TBlXiM87iM5CdppJY49yKQ67L9OhuUvXrtitmqnJlVaqgY9K2i95l4t7KmBAePGbdfm-hNI04kIwfLLAy-fDLGUbOQVnVQUqEeSevgf7E4s7w" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=andrewliang25/morphe-patches&type=date&legend=top-left&sealed_token=wmq23aagupD99LpnPmnuBYZf96xmHbGhV8iIcXKvUVhQnTCNUVF2JpgGdwyfP6URWdMcuGaz2rvT6i8TBlXiM87iM5CdppJY49yKQ67L9OhuUvXrtitmqnJlVaqgY9K2i95l4t7KmBAePGbdfm-hNI04kIwfLLAy-fDLGUbOQVnVQUqEeSevgf7E4s7w" />
+ </picture>
 </a>
 
 ## 📜 License

--- a/README.md
+++ b/README.md
@@ -86,6 +86,16 @@ of **Standard** install (which re-signs the APK).
 
 - [@f870103](https://github.com/f870103) — for lending a LINE account for testing, and for finding the LINE Pay app redirect URL.
 
+## ⭐ Star history
+
+<a href="https://www.star-history.com/?repos=andrewliang25%2Fmorphe-patches&type=date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=andrewliang25/morphe-patches&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=andrewliang25/morphe-patches&type=Date" />
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=andrewliang25/morphe-patches&type=Date" width="600" />
+  </picture>
+</a>
+
 ## 📜 License
 
 Andrew's Patches are licensed under the [GNU General Public License v3.0](LICENSE)

--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ of **Standard** install (which re-signs the APK).
 
 <a href="https://www.star-history.com/?repos=andrewliang25%2Fmorphe-patches&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=andrewliang25/morphe-patches&type=date&theme=dark&legend=top-left&sealed_token=wmq23aagupD99LpnPmnuBYZf96xmHbGhV8iIcXKvUVhQnTCNUVF2JpgGdwyfP6URWdMcuGaz2rvT6i8TBlXiM87iM5CdppJY49yKQ67L9OhuUvXrtitmqnJlVaqgY9K2i95l4t7KmBAePGbdfm-hNI04kIwfLLAy-fDLGUbOQVnVQUqEeSevgf7E4s7w" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=andrewliang25/morphe-patches&type=date&legend=top-left&sealed_token=wmq23aagupD99LpnPmnuBYZf96xmHbGhV8iIcXKvUVhQnTCNUVF2JpgGdwyfP6URWdMcuGaz2rvT6i8TBlXiM87iM5CdppJY49yKQ67L9OhuUvXrtitmqnJlVaqgY9K2i95l4t7KmBAePGbdfm-hNI04kIwfLLAy-fDLGUbOQVnVQUqEeSevgf7E4s7w" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=andrewliang25/morphe-patches&type=date&legend=top-left&sealed_token=wmq23aagupD99LpnPmnuBYZf96xmHbGhV8iIcXKvUVhQnTCNUVF2JpgGdwyfP6URWdMcuGaz2rvT6i8TBlXiM87iM5CdppJY49yKQ67L9OhuUvXrtitmqnJlVaqgY9K2i95l4t7KmBAePGbdfm-hNI04kIwfLLAy-fDLGUbOQVnVQUqEeSevgf7E4s7w" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=andrewliang25/morphe-patches&type=date&theme=dark&legend=top-left&sealed_token=bcBbvce_G1Ww6apQwWC74HNf7mWANZkAaRZC-jk1TFjdlCjsmb6zKtbPBByRyJB45-ZldU6RwekQ_WAKV_L62P8tuslW7Q6a39UdAaFAxan0cj5UX8WxgG3DwF68QJZq5GmmKaDE-njntBl3WJLxf6_jMvUI7Tq2ap83khC5cDb_Y12NL8p271Sk3fSN" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=andrewliang25/morphe-patches&type=date&legend=top-left&sealed_token=bcBbvce_G1Ww6apQwWC74HNf7mWANZkAaRZC-jk1TFjdlCjsmb6zKtbPBByRyJB45-ZldU6RwekQ_WAKV_L62P8tuslW7Q6a39UdAaFAxan0cj5UX8WxgG3DwF68QJZq5GmmKaDE-njntBl3WJLxf6_jMvUI7Tq2ap83khC5cDb_Y12NL8p271Sk3fSN" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=andrewliang25/morphe-patches&type=date&legend=top-left&sealed_token=bcBbvce_G1Ww6apQwWC74HNf7mWANZkAaRZC-jk1TFjdlCjsmb6zKtbPBByRyJB45-ZldU6RwekQ_WAKV_L62P8tuslW7Q6a39UdAaFAxan0cj5UX8WxgG3DwF68QJZq5GmmKaDE-njntBl3WJLxf6_jMvUI7Tq2ap83khC5cDb_Y12NL8p271Sk3fSN" />
  </picture>
 </a>
 


### PR DESCRIPTION
Adds a [star-history.com](https://www.star-history.com) chart to the README, between **Special thanks** and **License**.

Uses the theme-aware `<picture>` form star-history documents, so the chart follows the viewer's light/dark GitHub theme.

The section sits **outside** the `<!-- PATCHES_START EXPANDED -->` / `<!-- PATCHES_END -->` markers, so `.github/scripts/generate_patches_readme.py` won't rewrite it on release.

### ⚠️ Heads-up before merging

The chart endpoint currently returns **HTTP 500** for this repo:

```
$ curl -s "https://api.star-history.com/svg?repos=andrewliang25/morphe-patches&type=Date"
Repo andrewliang25/morphe-patches: timeout of 10000ms exceeded
```

Reproducible across `/svg` and `/chart`, every `type` value, ~10 attempts. It's upstream, not a snippet error — the identical URL for `andrewliang25/patched-apps` and `star-history/star-history` returns 200. Most likely a cold-cache/rate-limit hiccup on star-history's side.

Until it clears, the image renders broken. GitHub proxies README images through camo and retries, so recovery needs no repo change. Worth re-running the curl before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)