### PR TITLE
feat: add "Hide Shopping tab" patch

### DIFF
--- a/docs/line-patch-map.md
+++ b/docs/line-patch-map.md
@@ -155,6 +155,56 @@ row, and the sibling "Hide community button" which targets `OPEN_CHAT`).
 
 ---
 
+## Main bottom-navigation tabs
+
+Every tab patch in the bundle edits the **same** builder:
+`wy7.b.a() → List<jp.naver.line.android.activity.main.a>` (cached by `wy7.b.b()`), which appends
+each tab as an `sget-object <main.a const>` + `invoke-virtual ArrayList.add` pair. The enum
+`jp.naver.line.android.activity.main.a` is **not obfuscated**, so its constants are stable anchors —
+fingerprint on `returnType = "Ljava/util/List;"` + `fieldAccess(MAIN_TAB, "<CONST>")`, then
+`removeInstructions(index, 2)`.
+
+| Constant | Tracking name | Label resource | Shown when | Hidden by |
+|---|---|---|---|---|
+| `HOME` / `HOME26` / `GLOBALHOME` | `hometab` / `linehome` / `globalhome` | — | always (one of the three) | — |
+| `CHAT` | `chatlist` | — | always | — |
+| `COMMERCE` | `commercetab` | `gnb_commerce` — "Shopping" / ja **ショッピング** | `function.maintab.commercetab` (JP) | **Hide Shopping tab** |
+| `COMMERCE_TW` | `commercetwtab` | `tw_commerce_tab_gnb` — "Discover" / zh-TW **逛逛** | `function.maintab.commercetwtab` (TW) | **Hide Shopping tab** |
+| `SQUARE` | `squaretab` | — | `rm5.b.C()` | — |
+| `TIMELINE` | `timeline` | — | `db0.k0.a(m2)` | Hide VOOM tab |
+| `NEWS` / `NEWS_ROW` | `newstab` / `newsrowtab` | — | `s28.a.b()` / `kc3.d.a()` | Hide LINE TODAY tab |
+| `CALL` | `call` | — | `y28.d.c()` | — |
+| `MINI` / `WALLET` | `minitab` / `wallettab` | — | `m2.a().Y().d()` / `m2.a().H0().l()` | Hide Wallet tab |
+
+**`COMMERCE`, `COMMERCE_TW`, `SQUARE` and `TIMELINE` share one `if`/`else-if` chain** — they compete
+for a single slot and are mutually exclusive. That drives two rules:
+
+- **Remove the `sget`+`add` pair; never force the gate false.** Forcing `jw4.u.h()`
+  (`CommerceTabConfiguration.isCommerceTabEnabled`) false would fall *through* the chain and surface
+  `SQUARE` or `TIMELINE` in the freed slot — a tab the user never had. Removing just the body leaves
+  the branch's trailing `goto` intact, so the slot stays empty, which is what stock LINE does when
+  the commerce gate is on.
+- **Anchor each patch only on its own constants.** The tab patches run in arbitrary order against
+  the same method, and each fingerprint resolves *after* earlier patches have mutated it — so
+  anchoring on a constant another patch removes would break the match. (Already noted in
+  `hidevoomtab/Fingerprints.kt`; the same is why Hide Shopping tab anchors on neither
+  `TIMELINE` nor `MINI`/`WALLET`.)
+
+**A missing tab is safe everywhere.** Tab→index lookups are `Math.max(list.indexOf(...), 0)` (clamps
+to Home) in `jp/naver/line/android/activity/main/c.java`; `x66.d.a` only emits a `VoomSecondDepth`
+telemetry event; `qy4.f0` only writes the `ADDITIONAL_MAIN_TAB` pref. The bottom bar's layout carries
+a view per tab (`xy7.g` maps each constant to its `R.id.bnb_*`), so an absent list entry simply never
+renders.
+
+**The commerce tabs are region-gated, so they cannot be device-tested from TW.**
+`function.maintab.commercetab` is pushed by the server and is off outside JP — local proof stops at
+disassembling the patched `wy7/b.smali`. Hide Shopping tab was confirmed that way (both pairs gone,
+`if-eqz`/`goto` skeletons and the `SQUARE`/`TIMELINE` pairs intact, whole-dex branch-offset sweep
+clean, and all four tab patches coexisting under the full bundle); on-device confirmation comes from
+the JP reporter of issue #59.
+
+---
+
 ## Shipped / proposed patches (this line of work)
 
 | Patch (name) | Package | Targets |
@@ -166,6 +216,7 @@ row, and the sibling "Hide community button" which targets `OPEN_CHAT`).
 | Hide attach menu extra tools | `line.hideattachmenutools` | all server-driven `hg1.d` services |
 | Redirect LINE Pay | `line.disablepay` | `PayLaunchActivity` / `PayLiffActivity` onCreate (see below) |
 | Keep unsent messages | `line.keepunsent` | `g38.b0.invoke` — the unsend DB write (see below) |
+| Hide Shopping tab | `line.hideshoppingtab` | `COMMERCE` + `COMMERCE_TW` in `wy7.b.a()` (see above) |
 
 Each is an independent, `default = true`, user-facing `bytecodePatch` — one feature (or one feature's
 full set of entry points) per patch, matching the bundle's convention (cf. *Hide Wallet tab*,

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hideshoppingtab/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hideshoppingtab/Fingerprints.kt
@@ -1,0 +1,28 @@
+package app.andrewliang.patches.line.hideshoppingtab
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.fieldAccess
+
+private const val MAIN_TAB = "Ljp/naver/line/android/activity/main/a;"
+
+/**
+ * Matches `wy7.b.a()` — the main bottom-nav tab-list builder — via its access to the
+ * non-obfuscated commerce main-tab constants. The commerce slot has two regional variants,
+ * added by the same `if`/`else-if` chain: `COMMERCE` (Japan, label `gnb_commerce` =
+ * "Shopping" / "ショッピング", gated by `function.maintab.commercetab`) and `COMMERCE_TW`
+ * (Taiwan, label `tw_commerce_tab_gnb` = "Discover" / "逛逛", gated by
+ * `function.maintab.commercetwtab`). Matching both, in program order, yields the two
+ * `sget-object` indices whose `sget`+`ArrayList.add` pairs are removed.
+ *
+ * Constraining the return type to `List` keeps the enum's own `<clinit>` `sput`s — and the
+ * switch tables in `xy7.g` / `xy7.d` / `wy7.f0` — out of the match. Deliberately anchors on
+ * neither `MINI`/`WALLET` nor `TIMELINE`, which the Hide-Wallet-tab and Hide-VOOM-tab patches
+ * may remove first.
+ */
+internal object ShoppingTabListFingerprint : Fingerprint(
+    returnType = "Ljava/util/List;",
+    filters = listOf(
+        fieldAccess(definingClass = MAIN_TAB, name = "COMMERCE"),
+        fieldAccess(definingClass = MAIN_TAB, name = "COMMERCE_TW"),
+    ),
+)

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hideshoppingtab/HideShoppingTabPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hideshoppingtab/HideShoppingTabPatch.kt
@@ -1,0 +1,33 @@
+package app.andrewliang.patches.line.hideshoppingtab
+
+import app.andrewliang.patches.shared.Constants.COMPATIBILITY_LINE
+import app.morphe.patcher.extensions.InstructionExtensions.removeInstructions
+import app.morphe.patcher.patch.bytecodePatch
+
+@Suppress("unused")
+val hideShoppingTabPatch = bytecodePatch(
+    name = "Hide Shopping tab",
+    description = "Removes the Shopping tab from the main bottom navigation, covering both the " +
+        "Japan (Shopping / ショッピング) and Taiwan (Discover / 逛逛) variants.",
+    default = true,
+) {
+    compatibleWith(COMPATIBILITY_LINE)
+
+    // Remove the COMMERCE and COMMERCE_TW `sget-object` + following `ArrayList.add` pairs from
+    // the tab-list builder. Both live in the same `if`/`else-if` chain and are mutually
+    // exclusive (each is enabled by its own server setting, for its own region), so a user only
+    // ever sees one of them. Dropping only the `add` leaves the branch's trailing `goto` in
+    // place, so no other tab moves into the freed slot — matching stock LINE, which shows
+    // nothing there when the commerce gate is on.
+    // instructionMatches[0] = COMMERCE (earlier), [1] = COMMERCE_TW (later); remove the higher
+    // index first so the earlier one stays valid.
+    execute {
+        val matches = ShoppingTabListFingerprint.instructionMatches
+        val commerceIndex = matches[0].index
+        val commerceTwIndex = matches[1].index
+        ShoppingTabListFingerprint.method.apply {
+            removeInstructions(commerceTwIndex, 2)
+            removeInstructions(commerceIndex, 2)
+        }
+    }
+}


### PR DESCRIPTION
Closes #59.

## The tab is real

A JP user reported a **Shopping** tab in the bottom navigation that isn't visible from TW. It exists in LINE 26.11.0 already, region-gated:

| Constant | Label resource | Shown when |
|---|---|---|
| `jp.naver.line.android.activity.main.a.COMMERCE` | `gnb_commerce` — "Shopping" / ja **ショッピング** | `function.maintab.commercetab` (JP) |
| `…main.a.COMMERCE_TW` | `tw_commerce_tab_gnb` — "Discover" / zh-TW **逛逛** | `function.maintab.commercetwtab` (TW) |

The ja label matches the reporter's screenshot. The gate value is server-pushed, but the tab **list is assembled in LINE's own process** — `wy7.b.a()`, the same builder *Hide Wallet tab*, *Hide VOOM tab* and *Hide LINE TODAY tab* already edit — so it's patchable by the project's usual client-vs-server test.

## What the patch does

One `default = true` patch, **Hide Shopping tab**, removing the `sget-object` + `ArrayList.add` pair for **both** regional variants — they share a single slot and a user only ever sees one, so a single toggle covers both, mirroring how *Hide Wallet tab* covers `MINI`+`WALLET`.

Removing the pair rather than forcing the gate false is deliberate: `COMMERCE`/`COMMERCE_TW`/`SQUARE`/`TIMELINE` sit in one `if`/`else-if` chain, so a false gate would fall through and surface a tab the user never had. Dropping just the branch body leaves the trailing `goto` intact and the slot empty — what stock LINE does when the commerce gate is on.

The fingerprint anchors on `COMMERCE` + `COMMERCE_TW` only, never on `TIMELINE`/`MINI`/`WALLET`, so it can't be broken by a sibling tab patch removing those first.

## Verification

Region-gated off in TW, so local proof is bytecode-only:

- Applied exclusively against `base.apk`; `wy7/b.a()` disassembly confirms both `sget`+`add` pairs gone, the `if-eqz`/`goto` skeletons intact, and the `SQUARE`/`TIMELINE`/`NEWS`/`CALL` pairs untouched.
- Whole-dex branch-offset sweep (every `OffsetInstruction` target + every try range/handler) clean over all 628k methods.
- Full bundle applied: all 22 patches succeed together, and `wy7.b.a()` correctly ends up with only Home/Chat/Square/Call — the four tab patches don't interfere.

**On-device confirmation must come from JP** — @sygarh volunteered on #59. Please hold the `dev` to `main` merge until they confirm on the pre-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
