### PR TITLE
feat: add "Hide Home content feed" patch (issue #69)

### DIFF
--- a/docs/line-patch-map.md
+++ b/docs/line-patch-map.md
@@ -197,6 +197,118 @@ screenshot. That is the only step separating "the instructions are gone" from "t
 
 ---
 
+## Home tab modules
+
+The Home tab renders a single server-driven `List<m52.z>`. Everything on the tab is one of these
+modules — the friends list, the service icons, the ads, and the whole content feed below the friends
+list. Two patches filter that list.
+
+**The chain.** `v52.g.a(Ls52/i;Lm52/m0;)` assembles the list from the GCS response (one giant
+`packed-switch` over the payload oneof; **jadx fails on this method** — `Method not decompiled` — so
+read `apktool/smali_classes9/v52/g.smali`; the `FLEX` arm is separate, at `v52/g.smali:5748` and
+`jadx/sources/v52/j.java:191`). The list is stored as the first ctor arg (field `a`) of the Compose
+state `x72.h$a`, and rendered at `v72/c2.java:296-300` via `r72.d(z.f229498a, z.f229502e.getType())`.
+
+**Where to filter: `x72.h$a.<init>(List, Z×5, String, Long, Long, I, Z)`, index 0.** Every build path
+and every state copy funnels through this constructor, so one branchless
+`invoke-static {p1}` + `move-result-object p1` covers the whole tab. Two rules, both learned the hard
+way:
+
+- **The loop must live in a new method.** A backward-branching loop injected into an existing method
+  corrupts the branch layout into a runtime `VerifyError`. Add
+  `x72.h$a.filterHomeModules` / `filterHomeFeed` with `mutableClassDefBy(...).methods.add(...)` and
+  inject only the call.
+- **Both patches prepend at index 0, and that is safe.** Each is a pure `List → List` filter on `p1`,
+  so whichever patch applies second simply runs first — verified in the dex: the ctor starts with the
+  two `invoke-static` + `move-result-object v1` pairs chained, then the original
+  `Object.<init>` + `iput-object v1 → field a`.
+- The earlier target `i52.c.e` built only the Friends sub-tab list (a single
+  `FriendsSubTabFriendsList`), not the feed — confirmed via on-device logging.
+
+### Module type inventory (LINE 26.11.0) — 45 types
+
+`m52.a0` is a marker interface with one member, `getType() : String`. 43 implementations are nested
+in `m52/a0.java`; **two are top-level and easy to miss** (`m52.c0`, `m52.d0`).
+
+| `getType()` | Class | Surface | Status |
+|---|---|---|---|
+| `HomeContentsRecommendation` | `a0$s` | recommended stickers / content | **Hide Home modules** (device-confirmed) |
+| `HomePerformanceAd` | `a0$j0` | performance ads in the feed | **Hide Home modules** (device-confirmed) |
+| `FLEX` | `a0$f` | 即時夯話題 hot topics **and** the bottom promo/ad block | **Hide Home modules** (device-confirmed) |
+| `AdModel` | `a0$a` | generic ad module (`GcsAdModuleViewData` / `GcsAdMeta`) | **Hide Home modules** (static evidence only — never seen on device) |
+| `HomeFeedPost` | `a0$z` | OA / LINE NEWS post card | **Hide Home content feed** |
+| `HomeFeedLiveSingle` | `a0$w` | the `OA_LIVE` variant | **Hide Home content feed** |
+| `HomeFeedMatomeSingle` / `-Carousel` | `a0$y` / `a0$x` | AI-digest ("matome") news cards | **Hide Home content feed** |
+| `HomeFeedUnitBigVisual` / `-Grid` / `-Ranking` / `-ShortFormGrid` / `-Single` / `-SingleAndGrid` | `a0$b0`–`a0$g0` | content-unit layouts, each wrapping posts | **Hide Home content feed** |
+| `HomeFeedDefaultPageError` / `-DefaultPageLoading` / `HomeFeedError` / `HomeFeedSeedPostError` | `a0$t` / `a0$u` / `a0$v` / `a0$a0` | that feed's error & spinner placeholders | **Hide Home content feed** |
+| `FriendsSubTabFriendsList`, `-AllAlbum`, `-Calendar`, `-LatestNotifications`, `-RecentlyUpdatedProfiles` | `a0$i`, `a0$g`, `a0$h`, `a0$j`, `a0$k` | the friends list and its sub-tabs | kept |
+| `HomeSocialGraph`, `HomeRecentlyProfileUpdate`, `HomeActivityFriendList`, `GlobalHomeFriendList` | `a0$m0`, `a0$k0`, `a0$r`, `a0$o` | friend updates / profiles | kept |
+| `HomeServiceList`, `GlobalHomeServiceSection`, `SquareJoinedChatList`, `HomeNotificationHub` | `a0$l0`, `a0$p`, `a0$q0`, `a0$i0` | service icons, OpenChat list, notification hub | kept |
+| `HomeTopBanner`, `SafetyCheckBanner`, `HomeLimitedNetworkModeBanner` | `a0$o0`, `a0$p0`, `a0$h0` | banners (not identified as ads) | kept |
+| `GlobalHomePageError`, `GlobalHomeError`, `GlobalHomePageLoading` | `a0$l`, `a0$n`, `a0$m` | whole-tab error / loading | kept |
+| `CommerceTwTabFriendshipGifts`, `-GreetingBanners`, `-QuickPolls`, `-Shortcuts` | `a0$b`–`a0$e` | the TW commerce tab | kept |
+| `HomeActivityCard` | `a0$q` | recommendation surface (`contentList` / `extraContentList`) | **not blocked** — no device evidence |
+| `GcsHomeActivityHybridContentCard` | `m52.d0` (top-level) | the hybrid variant of the above | **not blocked** — no device evidence |
+| `HomeTabLypRecommendation` | `a0$n0` | LYP premium upsell | **not blocked** — belongs to *Disable LINE Premium*, see `line-premium-map.md` |
+| `GcsDummyHybridModule` | `m52.c0` (top-level) | dev/dummy, no renderer | kept |
+
+**Take this table from jadx, never from a smali grep.** 17 of the 43 nested classes are Kotlin
+singletons whose `getType()` returns a `static final` field, so a grep for the literal nearest
+`getType` silently reports a *neighbouring* method's string. `a0$m` is the trap: `getType()` returns
+`"GlobalHomePageLoading"` while its `toString()` says `"GlobalHomeDefaultPageLoading"`.
+
+### Why the content feed is matched by prefix
+
+Every type in the feed below the friends list starts with `HomeFeed` (network models `GcsHomeFeed*`,
+including `GcsHomeFeedScrollAffordance` — it is an infinite scroller). The server rotates between card
+variants, so a literal list reopens the hole on the next rotation; the extension tests
+`type.startsWith("HomeFeed")` instead. The error and loading placeholders are included on purpose, so
+no orphan spinner or error shell is left where the cards were.
+
+**No `function.*` config gate exists for this feed.** `function.hometab.*`, `function.line_home.*` and
+`function.my_home.*` carry no feed switch, so filtering the module list is the only cheap mechanism —
+this is not a "force the gate false" surface.
+
+### The feed is region-driven — plan for a remote tester
+
+Issue #69 (JP) reported LINE NEWS cards surviving every ad patch. The cards are `HomeFeedPost`,
+identified by `GcsHomeFeedPost.platform{type ∈ {OA_POST, YOUTUBE, LINE_NEWS, LIVE_PREVIEW}, name}` (the
+`carview! / LINE NEWS` header pair), `home_post_desc_linenews` = "LINE NEWS"
+(`values-ja/strings.xml:5218`), `lineNewsContent{title, imageUrl}`, `createdTime`, `likeReaction` (the
+きになる pill) and `home_post_menu_accounthide` (the ⋮ menu). Renderer `ze2.h extends l72.g<a0.z>`.
+
+They were never blocked because PR #15 locked the blocklist to what a **Taiwan** account renders —
+PR #14's `MorpheHomeModules` logcat showed `size=8` with **no** `HomeFeed*` type at all. Same lesson as
+the commerce tabs: a region-gated surface needs a pre-release and a tester in the region.
+
+**Diagnostic recipe** (from PR #11, revert before shipping): log every type at filter entry under tag
+`MorpheHomeModules`, then `adb logcat -c && adb logcat -s MorpheHomeModules`. No lines = the filter
+never ran; `ENTER` with no per-type lines = empty list at that point; per-type lines = the real strings.
+
+### Finer discriminators, if a type string is ever too coarse
+
+`m52.z` carries more than the payload: `f229498a` = module id (e.g.
+`home-feed-module_home-feed-default-page-loading`; **LINE itself filters on it** at `an2/d.java:75`),
+`f229499b` = module name, `f229500c`/`f229501d` = timestamps, `f229502e` = the `m52.a0` payload,
+`f229503f` = ACI gate enum `m52.m0` (`DISABLED` / `ACI_REQUIRED` / `ALWAYS`), `f229504g` = upstream
+request id, `f229505h` = global service key, `f229506i` = render kind (`FLEX` / `NATIVE` / `HYBRID`).
+Inside the `HomeFeedUnit*` payloads there is also `type: m52.l0` (`AUTO` / `PACKAGED` / `KEYWORD` /
+`FITTED` / `MANUAL`) and `contentType: m52.k0` (`MASS` / `CLUSTER` / `PERSONAL`).
+
+Renderers subclass `l72.g<T>` / `r72.b<T>` and register a `KClass`, so the renderer confirms a type
+actually paints: `a0$z`→`ze2/h.java`, `a0$x`→`mg2/h.java`, `a0$y`→`ng2/g.java`, `a0$s`→`tg2/n.java`,
+`a0$j0`→`ec2/f.java`, `a0$f`→`d62/r.java`, `a0$m0`→`f30/b.java`, `a0$l0`→`b30/b.java`,
+`a0$n0`→`ac2/k.java`, `m52.d0`→`sd2/i.java`.
+
+### Values that drift on a version bump
+
+`x72.h$a` (state class + ctor signature), `m52.z` field `e`, `m52.a0` and every `a0$*` letter suffix,
+the assembler `v52.g`, the consumer `v72.c2`. The **type strings themselves are server contract** and
+have been stable; re-run the jadx sweep over `m52/a0.java` to re-audit the `HomeFeed*` family, in case
+LINE adds a wanted module under that prefix.
+
+---
+
 ## Shipped / proposed patches (this line of work)
 
 | Patch (name) | Package | Targets |

--- a/extensions/extension/src/main/java/app/andrewliang/extension/HomeFeed.java
+++ b/extensions/extension/src/main/java/app/andrewliang/extension/HomeFeed.java
@@ -1,0 +1,42 @@
+package app.andrewliang.extension;
+
+/**
+ * Helper for the "Hide Home content feed" LINE patch.
+ *
+ * LINE's Home tab renders a server-driven list of typed modules (m52.a0, each with a stable
+ * getType() string), held as the module list of the Compose state x72.h$a. The patch iterates
+ * that list in injected smali and drops modules this helper flags — the extension only makes
+ * the String decision (it cannot reference the obfuscated LINE module classes).
+ *
+ * Everything below the friends list — the infinite-scrolling card stack — is one server feed
+ * whose module types all start with "HomeFeed" (network models GcsHomeFeed*). On LINE 26.11.0
+ * that is 14 types:
+ *   HomeFeedPost                    = an official-account / LINE NEWS post card
+ *   HomeFeedLiveSingle              = the OA_LIVE variant of the above
+ *   HomeFeedMatomeSingle/-Carousel  = AI-digest ("matome") news cards
+ *   HomeFeedUnitBigVisual, -Grid, -Ranking, -ShortFormGrid, -Single, -SingleAndGrid
+ *                                   = the content-unit card layouts, each wrapping posts
+ *   HomeFeedDefaultPageError, HomeFeedDefaultPageLoading, HomeFeedError, HomeFeedSeedPostError
+ *                                   = that feed's error / spinner placeholders
+ *
+ * Matching on the prefix rather than the 14 literals is deliberate: the server rotates between
+ * card variants (and between regions — a Taiwan account renders none of these, a Japanese one
+ * renders them), so a literal list would reopen the hole on the next rotation. The error and
+ * loading placeholders are included on purpose, so no orphan spinner or error shell is left
+ * behind where the cards were.
+ *
+ * The Home *modules* above the feed (recommended stickers/content, hot topics, ads) are a
+ * different patch — see HomeModules.
+ */
+public final class HomeFeed {
+
+    private HomeFeed() {}
+
+    /** Every module type in LINE's server-driven Home content feed starts with this. */
+    private static final String FEED_PREFIX = "HomeFeed";
+
+    /** @return true if a Home module of this type belongs to the content feed. */
+    public static boolean shouldHide(String type) {
+        return type != null && type.startsWith(FEED_PREFIX);
+    }
+}

--- a/extensions/extension/src/main/java/app/andrewliang/extension/HomeFeed.java
+++ b/extensions/extension/src/main/java/app/andrewliang/extension/HomeFeed.java
@@ -3,30 +3,31 @@ package app.andrewliang.extension;
 /**
  * Helper for the "Hide Home content feed" LINE patch.
  *
- * LINE's Home tab renders a server-driven list of typed modules (m52.a0, each with a stable
- * getType() string), held as the module list of the Compose state x72.h$a. The patch iterates
- * that list in injected smali and drops modules this helper flags — the extension only makes
- * the String decision (it cannot reference the obfuscated LINE module classes).
+ * The LINE Home tab shows one server-driven list of typed modules. Each module is an m52.a0
+ * with a stable getType() string. The list is the module list of the Compose state x72.h$a.
+ * The patch iterates that list in injected smali and drops the modules that this helper flags.
+ * The extension makes the String decision only, because it cannot reference the obfuscated
+ * LINE module classes.
  *
- * Everything below the friends list — the infinite-scrolling card stack — is one server feed
- * whose module types all start with "HomeFeed" (network models GcsHomeFeed*). On LINE 26.11.0
- * that is 14 types:
- *   HomeFeedPost                    = an official-account / LINE NEWS post card
- *   HomeFeedLiveSingle              = the OA_LIVE variant of the above
+ * The card stack below the friends list is one server feed, and it scrolls without end. The
+ * type of every module in this feed starts with "HomeFeed" (network models GcsHomeFeed*). On
+ * LINE 26.11.0 there are 14 types:
+ *   HomeFeedPost                    = an official account / LINE NEWS post card
+ *   HomeFeedLiveSingle              = the OA_LIVE variant of HomeFeedPost
  *   HomeFeedMatomeSingle/-Carousel  = AI-digest ("matome") news cards
  *   HomeFeedUnitBigVisual, -Grid, -Ranking, -ShortFormGrid, -Single, -SingleAndGrid
- *                                   = the content-unit card layouts, each wrapping posts
+ *                                   = the content-unit card layouts, each one holds posts
  *   HomeFeedDefaultPageError, HomeFeedDefaultPageLoading, HomeFeedError, HomeFeedSeedPostError
- *                                   = that feed's error / spinner placeholders
+ *                                   = the error and spinner placeholders of the same feed
  *
- * Matching on the prefix rather than the 14 literals is deliberate: the server rotates between
- * card variants (and between regions — a Taiwan account renders none of these, a Japanese one
- * renders them), so a literal list would reopen the hole on the next rotation. The error and
- * loading placeholders are included on purpose, so no orphan spinner or error shell is left
- * behind where the cards were.
+ * This helper tests the prefix and not the 14 literal strings. The server rotates between card
+ * variants, and it sends different variants to different regions. A Taiwan account gets none
+ * of these modules, but a Japanese account gets them. Thus a literal list does not cover the
+ * next rotation. The prefix also matches the error and loading types, so no empty spinner or
+ * error card stays on the tab.
  *
- * The Home *modules* above the feed (recommended stickers/content, hot topics, ads) are a
- * different patch — see HomeModules.
+ * The Home modules above the feed are a different patch. See HomeModules for the recommended
+ * stickers, the hot topics and the ads.
  */
 public final class HomeFeed {
 

--- a/extensions/extension/src/main/java/app/andrewliang/extension/HomeModules.java
+++ b/extensions/extension/src/main/java/app/andrewliang/extension/HomeModules.java
@@ -16,11 +16,11 @@ import java.util.Set;
  *   HomePerformanceAd          = performance ad modules in the feed
  *   FLEX                       = 即時夯話題 (real-time hot topics) and the bottom promo/ad block
  *
- * AdModel is blocklisted on static evidence only (it is backed by the GcsAdModuleViewData /
- * GcsAdMeta server models, so it is an ad module) — it never appeared in the device capture, so
- * it is unverified rather than confirmed, and harmless if the server never sends it.
+ * AdModel is in the blocklist on static evidence only. The GcsAdModuleViewData and GcsAdMeta
+ * server models back it, thus it is an ad module. But it did not appear in the device capture,
+ * so it is not confirmed. If the server never sends AdModel, the entry does no harm.
  *
- * The content feed below the friends list is a separate patch — see HomeFeed.
+ * A separate patch hides the content feed below the friends list. See HomeFeed.
  */
 public final class HomeModules {
 
@@ -32,7 +32,7 @@ public final class HomeModules {
         HIDDEN.add("HomeContentsRecommendation");
         HIDDEN.add("HomePerformanceAd");
         HIDDEN.add("FLEX");
-        // Unverified on device — see the note above.
+        // Not confirmed on device. See the class comment.
         HIDDEN.add("AdModel");
     }
 

--- a/extensions/extension/src/main/java/app/andrewliang/extension/HomeModules.java
+++ b/extensions/extension/src/main/java/app/andrewliang/extension/HomeModules.java
@@ -15,6 +15,12 @@ import java.util.Set;
  *   HomeContentsRecommendation = recommended stickers/content
  *   HomePerformanceAd          = performance ad modules in the feed
  *   FLEX                       = 即時夯話題 (real-time hot topics) and the bottom promo/ad block
+ *
+ * AdModel is blocklisted on static evidence only (it is backed by the GcsAdModuleViewData /
+ * GcsAdMeta server models, so it is an ad module) — it never appeared in the device capture, so
+ * it is unverified rather than confirmed, and harmless if the server never sends it.
+ *
+ * The content feed below the friends list is a separate patch — see HomeFeed.
  */
 public final class HomeModules {
 
@@ -26,6 +32,8 @@ public final class HomeModules {
         HIDDEN.add("HomeContentsRecommendation");
         HIDDEN.add("HomePerformanceAd");
         HIDDEN.add("FLEX");
+        // Unverified on device — see the note above.
+        HIDDEN.add("AdModel");
     }
 
     /** @return true if a Home module of this type should be hidden. */

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidehomefeed/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidehomefeed/Fingerprints.kt
@@ -3,15 +3,15 @@ package app.andrewliang.patches.line.hidehomefeed
 import app.morphe.patcher.Fingerprint
 
 /**
- * `x72.h$a.<init>(List<m52.z>, ...)` — the constructor of the Home Compose UI state that holds
- * the rendered module list (stored into field `a`, the first ctor arg). Every feed build path
- * (the v52.g / v52.j assemblers, and state copies) funnels through this constructor, so
- * filtering the list argument here covers the whole rendered feed in one place.
+ * `x72.h$a.<init>(List<m52.z>, ...)` — the constructor of the Home Compose UI state. The state
+ * holds the module list that the tab shows, in field `a`, the first ctor argument. Every feed
+ * build path goes to this constructor: the v52.g and v52.j assemblers, and the state copies.
+ * One filter on the list argument here thus covers the whole feed.
  *
- * Deliberately a copy of `hidehomemodules`' fingerprint of the same method rather than a shared
- * object: the two patches are independent and either can be applied alone. They both prepend a
- * `List -> List` filter call at index 0 of this constructor, which composes in any order (see
- * HideHomeFeedPatch).
+ * This object is a copy of the fingerprint in `hidehomemodules` for the same method, and not a
+ * shared object. The two patches are independent, and the user can apply either one alone. Both
+ * prepend a `List -> List` filter call at index 0 of this constructor. The order does not matter
+ * (see HideHomeFeedPatch).
  */
 internal object HomeStateCtorFingerprint : Fingerprint(
     definingClass = "Lx72/h\$a;",

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidehomefeed/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidehomefeed/Fingerprints.kt
@@ -1,0 +1,29 @@
+package app.andrewliang.patches.line.hidehomefeed
+
+import app.morphe.patcher.Fingerprint
+
+/**
+ * `x72.h$a.<init>(List<m52.z>, ...)` — the constructor of the Home Compose UI state that holds
+ * the rendered module list (stored into field `a`, the first ctor arg). Every feed build path
+ * (the v52.g / v52.j assemblers, and state copies) funnels through this constructor, so
+ * filtering the list argument here covers the whole rendered feed in one place.
+ *
+ * Deliberately a copy of `hidehomemodules`' fingerprint of the same method rather than a shared
+ * object: the two patches are independent and either can be applied alone. They both prepend a
+ * `List -> List` filter call at index 0 of this constructor, which composes in any order (see
+ * HideHomeFeedPatch).
+ */
+internal object HomeStateCtorFingerprint : Fingerprint(
+    definingClass = "Lx72/h\$a;",
+    name = "<init>",
+    returnType = "V",
+    parameters = listOf(
+        "Ljava/util/List;",
+        "Z", "Z", "Z", "Z", "Z",
+        "Ljava/lang/String;",
+        "Ljava/lang/Long;",
+        "Ljava/lang/Long;",
+        "I",
+        "Z",
+    ),
+)

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidehomefeed/HideHomeFeedPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidehomefeed/HideHomeFeedPatch.kt
@@ -16,29 +16,30 @@ private const val FILTER_DESC = "(Ljava/util/List;)Ljava/util/List;"
 @Suppress("unused")
 val hideHomeFeedPatch = bytecodePatch(
     name = "Hide Home content feed",
-    description = "Removes the recommended content feed below the friends list on the Home tab " +
-        "— LINE NEWS and official-account post cards, live cards, and the content and ranking " +
-        "units. The friends list, the service icons and the rest of the Home tab are unaffected.",
+    description = "Removes the content feed below the friends list on the Home tab. The feed " +
+        "shows LINE NEWS posts, official account posts, live cards, content units, and ranking " +
+        "units. The friends list, the service icons, and the other Home modules do not change.",
     default = true,
 ) {
     compatibleWith(COMPATIBILITY_LINE)
 
     extendWith("extensions/extension.mpe")
 
-    // Same mechanism as "Hide Home modules", on the same list: the rendered Home feed is a
-    // List<m52.z> (each z.e a typed m52.a0 module) stored as the first ctor arg (field `a`) of
-    // the Compose state x72.h$a. Filter that list to drop modules whose z.e.getType() belongs to
-    // the server-driven content feed (every such type starts with "HomeFeed" — see the HomeFeed
-    // extension).
+    // Same mechanism as "Hide Home modules", and on the same list. The Home feed is a
+    // List<m52.z>. Each element holds a typed m52.a0 module in field z.e. The list is the first
+    // ctor argument (field `a`) of the Compose state x72.h$a. This patch filters the list and
+    // drops each module whose z.e.getType() belongs to the server content feed. Every type in
+    // that feed starts with "HomeFeed" — see the HomeFeed extension.
     //
-    // The filtering loop is a new method x72.h$a.filterHomeFeed (backward-branching loops corrupt
-    // an existing method's layout when injected inline -> VerifyError). We then inject a
-    // branchless call at the top of x72.h$a.<init> to replace p1 (the list) with its filtered copy
-    // before it's stored. One constructor covers every feed build path + copies.
+    // The loop lives in a new method, x72.h$a.filterHomeFeed. If a patch injects a loop with a
+    // backward branch inline, the loop corrupts the layout of an existing method. ART then
+    // throws a VerifyError. At the top of x72.h$a.<init> the patch injects a call with no
+    // branch. The call replaces p1 (the list) with the filtered copy before the constructor
+    // stores it. One constructor covers every feed build path and every state copy.
     //
-    // "Hide Home modules" prepends the same shape of call at the same index. Both are pure
-    // List -> List filters on p1, so whichever patch applies second simply runs first — the
-    // result is identical either way.
+    // "Hide Home modules" prepends the same call shape at the same index. Both are pure
+    // List -> List filters on p1. Thus the patch that applies second runs first, and the
+    // result is the same either way.
     execute {
         // 1. Add the static filter helper method to x72.h$a.
         val cls = mutableClassDefBy(HOME_STATE)
@@ -83,8 +84,9 @@ val hideHomeFeedPatch = bytecodePatch(
             """,
         )
 
-        // 2. At the top of x72.h$a.<init>, replace the list param (p1) with its filtered copy
-        //    before it is stored. Branchless (invoke + move-result), reuses p1 (`.locals 0`).
+        // 2. At the top of x72.h$a.<init>, replace the list parameter (p1) with the filtered
+        //    copy before the constructor stores it. The call has no branch (invoke +
+        //    move-result) and it reuses p1 (`.locals 0`).
         HomeStateCtorFingerprint.method.addInstructions(
             0,
             """

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidehomefeed/HideHomeFeedPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidehomefeed/HideHomeFeedPatch.kt
@@ -1,4 +1,4 @@
-package app.andrewliang.patches.line.hidehomemodules
+package app.andrewliang.patches.line.hidehomefeed
 
 import app.andrewliang.patches.shared.Constants.COMPATIBILITY_LINE
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
@@ -10,31 +10,33 @@ import com.android.tools.smali.dexlib2.immutable.ImmutableMethod
 import com.android.tools.smali.dexlib2.immutable.ImmutableMethodParameter
 
 private const val HOME_STATE = "Lx72/h\$a;"
-private const val FILTER_NAME = "filterHomeModules"
+private const val FILTER_NAME = "filterHomeFeed"
 private const val FILTER_DESC = "(Ljava/util/List;)Ljava/util/List;"
 
 @Suppress("unused")
-val hideHomeModulesPatch = bytecodePatch(
-    name = "Hide Home modules",
-    description = "Hides clutter modules from the Home tab: the recommended stickers and content " +
-        "section, the real-time hot-topics (即時夯話題) block, and the Home ad modules. The " +
-        "content feed below the friends list is a separate patch.",
+val hideHomeFeedPatch = bytecodePatch(
+    name = "Hide Home content feed",
+    description = "Removes the recommended content feed below the friends list on the Home tab " +
+        "— LINE NEWS and official-account post cards, live cards, and the content and ranking " +
+        "units. The friends list, the service icons and the rest of the Home tab are unaffected.",
     default = true,
 ) {
     compatibleWith(COMPATIBILITY_LINE)
 
     extendWith("extensions/extension.mpe")
 
-    // The rendered Home feed is a List<m52.z> (each z.e a typed m52.a0 module) stored as the
-    // first ctor arg (field `a`) of the Compose state x72.h$a. Filter that list to drop
-    // modules whose z.e.getType() is blocklisted.
+    // Same mechanism as "Hide Home modules", on the same list: the rendered Home feed is a
+    // List<m52.z> (each z.e a typed m52.a0 module) stored as the first ctor arg (field `a`) of
+    // the Compose state x72.h$a. Filter that list to drop modules whose z.e.getType() belongs to
+    // the server-driven content feed (every such type starts with "HomeFeed" — see the HomeFeed
+    // extension).
     //
-    // The filtering loop is a new method x72.h$a.filterHomeModules (backward-branching loops
-    // corrupt an existing method's layout when injected inline -> VerifyError). We then inject
-    // a branchless call at the top of x72.h$a.<init> to replace p1 (the list) with its
-    // filtered copy before it's stored. One constructor covers every feed build path + copies.
+    // The filtering loop is a new method x72.h$a.filterHomeFeed (backward-branching loops corrupt
+    // an existing method's layout when injected inline -> VerifyError). We then inject a
+    // branchless call at the top of x72.h$a.<init> to replace p1 (the list) with its filtered copy
+    // before it's stored. One constructor covers every feed build path + copies.
     //
-    // "Hide Home content feed" prepends the same shape of call at the same index. Both are pure
+    // "Hide Home modules" prepends the same shape of call at the same index. Both are pure
     // List -> List filters on p1, so whichever patch applies second simply runs first — the
     // result is identical either way.
     execute {
@@ -71,7 +73,7 @@ val hideHomeModulesPatch = bytecodePatch(
                 iget-object v3, v2, Lm52/z;->e:Lm52/a0;
                 invoke-interface {v3}, Lm52/a0;->getType()Ljava/lang/String;
                 move-result-object v3
-                invoke-static {v3}, Lapp/andrewliang/extension/HomeModules;->shouldHide(Ljava/lang/String;)Z
+                invoke-static {v3}, Lapp/andrewliang/extension/HomeFeed;->shouldHide(Ljava/lang/String;)Z
                 move-result v3
                 if-nez v3, :loop
                 invoke-virtual {v0, v2}, Ljava/util/ArrayList;->add(Ljava/lang/Object;)Z

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidehomemodules/HideHomeModulesPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidehomemodules/HideHomeModulesPatch.kt
@@ -16,9 +16,9 @@ private const val FILTER_DESC = "(Ljava/util/List;)Ljava/util/List;"
 @Suppress("unused")
 val hideHomeModulesPatch = bytecodePatch(
     name = "Hide Home modules",
-    description = "Hides clutter modules from the Home tab: the recommended stickers and content " +
-        "section, the real-time hot-topics (即時夯話題) block, and the Home ad modules. The " +
-        "content feed below the friends list is a separate patch.",
+    description = "Hides clutter modules on the Home tab: the recommended stickers and content " +
+        "section, the real-time hot-topics (即時夯話題) block, and the ad modules. A separate " +
+        "patch hides the content feed below the friends list.",
     default = true,
 ) {
     compatibleWith(COMPATIBILITY_LINE)
@@ -34,9 +34,9 @@ val hideHomeModulesPatch = bytecodePatch(
     // a branchless call at the top of x72.h$a.<init> to replace p1 (the list) with its
     // filtered copy before it's stored. One constructor covers every feed build path + copies.
     //
-    // "Hide Home content feed" prepends the same shape of call at the same index. Both are pure
-    // List -> List filters on p1, so whichever patch applies second simply runs first — the
-    // result is identical either way.
+    // "Hide Home content feed" prepends the same call shape at the same index. Both are pure
+    // List -> List filters on p1. Thus the patch that applies second runs first, and the
+    // result is the same either way.
     execute {
         // 1. Add the static filter helper method to x72.h$a.
         val cls = mutableClassDefBy(HOME_STATE)


### PR DESCRIPTION
Fixes the surviving "ad feed" in #69.

## What was wrong

The reporter's cards (JP, `carview!` / `KOREA WAVE` under `LINE NEWS`) are **`HomeFeedPost`** — `m52.a0$z`, payload `GcsHomeFeedPost`, renderer `ze2.h`. Identified by `platform{type` ∈ `{OA_POST, YOUTUBE, LINE_NEWS, LIVE_PREVIEW}, name}` (the provider + `LINE NEWS` header pair), `home_post_desc_linenews` = "LINE NEWS", `lineNewsContent{title, imageUrl}`, `likeReaction` (the きになる pill) and `home_post_menu_accounthide` (the ⋮ menu).

`Hide Home modules` filters the Home module list against **three** literals, and `HomeFeedPost` is one of **14** `HomeFeed*` types none of them covered. Not a mechanism bug — the existing filter already sees these modules. The blocklist was locked in #15 to what a **Taiwan** account renders, and #14's logcat showed `size=8` with no `HomeFeed*` type at all. The feed is region-driven.

## Why a separate patch

The feed below the friends list is one server-driven surface (`GcsHomeFeed*`, an infinite scroller) and a genuinely different thing from the ad/recommendation modules above it, so users can keep one and drop the other. A 3-way ads/recommendations/feed split is impossible: `FLEX` is device-confirmed as **both** the 即時夯話題 block and the bottom ad.

| Patch | Types |
|---|---|
| `Hide Home modules` (existing) | `HomeContentsRecommendation`, `HomePerformanceAd`, `FLEX`, **+ `AdModel`** |
| **`Hide Home content feed`** (new, `default = true`) | the 14 `HomeFeed*` types |

Matching on the `HomeFeed` **prefix** rather than 14 literals, so a server rotating between card variants can't reopen the hole. Error/loading placeholders are included on purpose — no orphan spinner where the cards were. `AdModel` joins the ads side on **static evidence only** (backed by `GcsAdModuleViewData`/`GcsAdMeta`; never seen on device), and is marked as such in the code.

## Mechanism — unchanged

Identical to `hidehomemodules`: the loop lives in a **new** method `x72.h$a.filterHomeFeed` (a backward branch injected inline gives a `VerifyError`), with a branchless `invoke-static {p1}` + `move-result-object p1` at index 0 of `x72.h$a.<init>`. Both patches prepend at that index; each is a pure `List -> List` filter on `p1`, so whichever applies second simply runs first.

## Verified locally (LINE 26.11.0)

- `list-patches` shows both patches with the new descriptions.
- Feed-only APK: `filterHomeFeed` present; ctor index 0/1 = `invoke-static filterHomeFeed` + `move-result-object v1`.
- Both applied: the ctor starts with **both** filters chained on `v1`, then the original `Object.<init>` + `iput-object v1` into field `a`.
- Extension logic really in the dex: `HomeFeed.shouldHide` has the `"HomeFeed"` const-string + `String.startsWith`; `HomeModules` carries `"AdModel"`.
- Whole-dex branch-offset / try-block sweep clean on both APKs (`badBranches=0 badTryOrHandler=0`).

**Device confirmation must come from the reporter** — a TW account renders none of these modules, so a local install proves nothing here. Same situation as the commerce tabs in #59.

## Docs

`docs/line-patch-map.md` gains a **Home tab modules** section: the `v52.g` -> `x72.h$a` -> `v72.c2` chain, all **45** module types with per-patch status, `m52.z`'s finer discriminators, the renderer map, the region caveat, the PR #11 diagnostic recipe — and the trap that 17 singleton modules return `getType()` from a `static final` field, so a smali grep reports a *neighbouring* method's string (`a0$m.getType()` = `GlobalHomePageLoading`, `toString()` = `GlobalHomeDefaultPageLoading`).

Separately worth filing: `HomeTabLypRecommendation` (`a0$n0`) is an LYP premium upsell module that `hidepremium` doesn't touch. Left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
