### PR TITLE
fix: hide the Home tab LYP upsell under "Disable LINE Premium"

### DIFF
--- a/docs/line-premium-map.md
+++ b/docs/line-premium-map.md
@@ -214,6 +214,43 @@ selected **by shape**, not by its drift-prone name: of `k0`'s three `()Z` method
 `invoke-virtual`; `r()` opens with an `iget-object` of a `Lkotlin/Lazy;` read via `invoke-interface`).
 `j()` is `.locals 0`, so the injection writes `p0`.
 
+### Third lever: the Home tab upsell module (required for the Home tab)
+
+The master lever does not reach the LYP upsell on the **Home tab**. The Home tab shows one
+server-driven `List<m52.z>` of typed modules, and this upsell is the module of type
+**`HomeTabLypRecommendation`** (`m52.a0$n0`, payload `m52.y`, renderer `ac2.k`, view model `ac2.n`).
+
+**Why the gate flip misses it:** nothing on that render path reads a premium gate. `ac2.k` and
+`ac2.n` reference neither the facade `b13.l` nor the market config `e13.a`, so the module paints
+whenever the server sends it — market gate false or not. The server decides whether to send it, and
+the client renders what arrives.
+
+**What the patch does:** it drops the module from the list instead of flipping another gate. That
+also keeps the lesson from the Settings ▸ Chats crash — a gate flipped without its siblings produced
+a state LINE never ships, whereas an absent module is a state the tab already handles (every module
+in the list is optional).
+
+The filter goes on `x72.h$a.<init>(List, Z×5, String, Long, Long, I, Z)`, at index 0: a new method
+`x72.h$a.filterPremiumModules(List)List`, plus a branchless `invoke-static {p1}` +
+`move-result-object p1` call. Notes on that surface:
+
+- **The loop must live in a new method.** A loop with a backward branch injected inline corrupts the
+  layout of an existing method, and ART then throws a `VerifyError`.
+- **One literal comparison needs no extension.** The type string is compared in smali, with the
+  literal as the receiver of `String.equals`, so a null type is safe. This patch stays free of
+  extension code.
+- **Three patches prepend at that same index** — this one, `Hide Home modules` and
+  `Hide Home content feed`. All three are pure `List -> List` filters on `p1`, so the patch that
+  applies last runs first and the result is the same in any order. Verified in the dex: the three
+  `invoke-static` + `move-result-object v1` pairs chain, then the original `Object.<init>` and
+  `iput-object v1` into field `a`.
+
+The full Home module inventory (45 types) is in `line-patch-map.md`, section "Home tab modules".
+
+**Not confirmed on device.** This is a static finding: the type never appeared in the on-device Home
+module capture from a Taiwan account (8 modules, no `HomeTabLypRecommendation`). The module list is
+region-driven and server-driven, so this needs a tester whose account gets the upsell.
+
 ### Known survivors: premium unsend upsells (patch `Hide premium unsend upsells`)
 
 Two premium-unsend surfaces read config directly, bypassing `e13.a.d()`, so the master lever doesn't

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidepremium/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidepremium/Fingerprints.kt
@@ -42,12 +42,12 @@ internal object PremiumBackupFacadeFingerprint : Fingerprint(
 /**
  * `x72.h$a.<init>(List<m52.z>, ...)` — the constructor of the Home Compose UI state. The state
  * holds the module list that the tab shows, in field `a`, the first ctor argument. The Home LYP
- * upsell module reaches the tab in that list, and the master premium lever does not stop it: the
- * module renderer `ac2.k` and its view model `ac2.n` read no premium gate at all.
+ * upsell module comes to the tab in that list. The master premium lever does not hide it,
+ * because the module renderer `ac2.k` and its view model `ac2.n` read no premium gate.
  *
  * This object is a third copy of the same fingerprint, after `hidehomemodules` and
- * `hidehomefeed`. Each patch keeps its own copy, because the three are independent and the user
- * can apply any one of them alone. All three prepend a `List -> List` filter call at index 0 of
+ * `hidehomefeed`. Each patch keeps its own copy, because the three patches are independent. The
+ * user can apply each one alone. All three prepend a `List -> List` filter call at index 0 of
  * this constructor. The order does not matter (see HidePremiumPatch).
  */
 internal object HomeStateCtorFingerprint : Fingerprint(

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidepremium/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidepremium/Fingerprints.kt
@@ -38,3 +38,29 @@ internal object PremiumBackupFacadeFingerprint : Fingerprint(
         string("PremiumBackupStatusSyncWorker"),
     ),
 )
+
+/**
+ * `x72.h$a.<init>(List<m52.z>, ...)` — the constructor of the Home Compose UI state. The state
+ * holds the module list that the tab shows, in field `a`, the first ctor argument. The Home LYP
+ * upsell module reaches the tab in that list, and the master premium lever does not stop it: the
+ * module renderer `ac2.k` and its view model `ac2.n` read no premium gate at all.
+ *
+ * This object is a third copy of the same fingerprint, after `hidehomemodules` and
+ * `hidehomefeed`. Each patch keeps its own copy, because the three are independent and the user
+ * can apply any one of them alone. All three prepend a `List -> List` filter call at index 0 of
+ * this constructor. The order does not matter (see HidePremiumPatch).
+ */
+internal object HomeStateCtorFingerprint : Fingerprint(
+    definingClass = "Lx72/h\$a;",
+    name = "<init>",
+    returnType = "V",
+    parameters = listOf(
+        "Ljava/util/List;",
+        "Z", "Z", "Z", "Z", "Z",
+        "Ljava/lang/String;",
+        "Ljava/lang/Long;",
+        "Ljava/lang/Long;",
+        "I",
+        "Z",
+    ),
+)

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidepremium/HidePremiumPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidepremium/HidePremiumPatch.kt
@@ -3,9 +3,19 @@ package app.andrewliang.patches.line.hidepremium
 import app.andrewliang.patches.shared.Constants.COMPATIBILITY_LINE
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
+import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.builder.MutableMethodImplementation
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import com.android.tools.smali.dexlib2.immutable.ImmutableMethod
+import com.android.tools.smali.dexlib2.immutable.ImmutableMethodParameter
+
+private const val HOME_STATE = "Lx72/h\$a;"
+private const val FILTER_NAME = "filterPremiumModules"
+private const val FILTER_DESC = "(Ljava/util/List;)Ljava/util/List;"
+private const val LYP_MODULE_TYPE = "HomeTabLypRecommendation"
 
 @Suppress("unused")
 val hidePremiumPatch = bytecodePatch(
@@ -92,6 +102,79 @@ val hidePremiumPatch = bytecodePatch(
             """
                 const/4 p0, 0x0
                 return p0
+            """,
+        )
+
+        // Third lever: the Home tab upsell module. The Home tab shows one server-driven list of
+        // typed modules, and the LYP recommendation is the module of type
+        // "HomeTabLypRecommendation" (m52.a0$n0, payload m52.y). The master lever does not reach
+        // it. Its renderer ac2.k and its view model ac2.n read no premium gate, so the module
+        // paints whenever the server sends it — even with the market gate false.
+        //
+        // So drop it from the list instead of flipping another gate. The list is the first ctor
+        // argument (field `a`) of the Compose state x72.h$a, and every build path goes to that
+        // constructor. One literal comparison needs no extension code, so this patch stays free
+        // of extensions.
+        //
+        // The loop lives in a new method, x72.h$a.filterPremiumModules. If a patch injects a loop
+        // with a backward branch inline, the loop corrupts the layout of an existing method. ART
+        // then throws a VerifyError.
+        //
+        // "Hide Home modules" and "Hide Home content feed" prepend the same call shape at the
+        // same index. All three are pure List -> List filters on p1, thus the patch that applies
+        // last runs first, and the result is the same in any order.
+        val homeState = mutableClassDefBy(HOME_STATE)
+        val filter = MutableMethod(
+            ImmutableMethod(
+                HOME_STATE,
+                FILTER_NAME,
+                listOf(ImmutableMethodParameter("Ljava/util/List;", null, null)),
+                "Ljava/util/List;",
+                AccessFlags.PUBLIC.value or AccessFlags.STATIC.value,
+                null,
+                null,
+                MutableMethodImplementation(6),
+            ),
+        )
+        homeState.methods.add(filter)
+        // p0 = input List. v0 = result ArrayList, v1 = iterator, v2 = element, v3 = type/bool,
+        // v4 = the literal. The literal is the receiver of equals(), so a null type is safe.
+        filter.addInstructions(
+            0,
+            """
+                new-instance v0, Ljava/util/ArrayList;
+                invoke-direct {v0}, Ljava/util/ArrayList;-><init>()V
+                invoke-interface {p0}, Ljava/util/List;->iterator()Ljava/util/Iterator;
+                move-result-object v1
+                :loop
+                invoke-interface {v1}, Ljava/util/Iterator;->hasNext()Z
+                move-result v2
+                if-eqz v2, :done
+                invoke-interface {v1}, Ljava/util/Iterator;->next()Ljava/lang/Object;
+                move-result-object v2
+                check-cast v2, Lm52/z;
+                iget-object v3, v2, Lm52/z;->e:Lm52/a0;
+                invoke-interface {v3}, Lm52/a0;->getType()Ljava/lang/String;
+                move-result-object v3
+                const-string v4, "$LYP_MODULE_TYPE"
+                invoke-virtual {v4, v3}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
+                move-result v3
+                if-nez v3, :loop
+                invoke-virtual {v0, v2}, Ljava/util/ArrayList;->add(Ljava/lang/Object;)Z
+                goto :loop
+                :done
+                return-object v0
+            """,
+        )
+
+        // At the top of x72.h$a.<init>, replace the list parameter (p1) with the filtered copy
+        // before the constructor stores it. The call has no branch (invoke + move-result) and it
+        // reuses p1 (`.locals 0`).
+        HomeStateCtorFingerprint.method.addInstructions(
+            0,
+            """
+                invoke-static {p1}, $HOME_STATE->$FILTER_NAME$FILTER_DESC
+                move-result-object p1
             """,
         )
     }

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidepremium/HidePremiumPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidepremium/HidePremiumPatch.kt
@@ -106,23 +106,23 @@ val hidePremiumPatch = bytecodePatch(
         )
 
         // Third lever: the Home tab upsell module. The Home tab shows one server-driven list of
-        // typed modules, and the LYP recommendation is the module of type
-        // "HomeTabLypRecommendation" (m52.a0$n0, payload m52.y). The master lever does not reach
-        // it. Its renderer ac2.k and its view model ac2.n read no premium gate, so the module
-        // paints whenever the server sends it — even with the market gate false.
+        // typed modules. The LYP recommendation is the module of type "HomeTabLypRecommendation"
+        // (m52.a0$n0, payload m52.y). The master lever does not hide it. Its renderer ac2.k and
+        // its view model ac2.n read no premium gate. As a result the tab shows the module
+        // whenever the server sends it, and a false market gate changes nothing.
         //
-        // So drop it from the list instead of flipping another gate. The list is the first ctor
-        // argument (field `a`) of the Compose state x72.h$a, and every build path goes to that
-        // constructor. One literal comparison needs no extension code, so this patch stays free
-        // of extensions.
+        // Thus this patch removes the module from the list. It does not flip another gate. The
+        // list is the first ctor argument (field `a`) of the Compose state x72.h$a. Every build
+        // path goes to that constructor. One literal comparison needs no extension code, so this
+        // patch declares no extension.
         //
         // The loop lives in a new method, x72.h$a.filterPremiumModules. If a patch injects a loop
         // with a backward branch inline, the loop corrupts the layout of an existing method. ART
         // then throws a VerifyError.
         //
         // "Hide Home modules" and "Hide Home content feed" prepend the same call shape at the
-        // same index. All three are pure List -> List filters on p1, thus the patch that applies
-        // last runs first, and the result is the same in any order.
+        // same index. All three are pure List -> List filters on p1. Thus the patch that applies
+        // last runs first, and the result is the same in every order.
         val homeState = mutableClassDefBy(HOME_STATE)
         val filter = MutableMethod(
             ImmutableMethod(


### PR DESCRIPTION
Closes #71.

## What survived the master lever

`Disable LINE Premium` says it hides all LYP surfaces, but the upsell on the **Home tab** stayed. The Home tab shows one server-driven `List<m52.z>` of typed modules, and this upsell is the module of type **`HomeTabLypRecommendation`** (`m52.a0$n0`, payload `m52.y`, renderer `ac2.k`, view model `ac2.n`).

**Why the gate flip misses it:** nothing on that render path reads a premium gate. `ac2.k` and `ac2.n` reference neither the facade `b13.l` nor the market config `e13.a`, so the module paints whenever the server sends it — `e13.a.d() == false` or not. I checked this before writing any code; it is the reason the fix is not a fourth gate.

## The fix — drop the module, do not flip a gate

An absent module is a state the tab already handles, because every module in that list is optional. A gate flipped without its siblings is what killed **Settings ▸ Chats** in #60, and `line-premium-map.md` now records why this surface gets the other treatment.

- New method `x72.h$a.filterPremiumModules(List)List`, plus a branchless `invoke-static {p1}` + `move-result-object p1` at index 0 of `x72.h$a.<init>`. The loop needs its own method: a backward branch injected inline corrupts the layout of an existing method, and ART then throws a `VerifyError`.
- **No extension code.** One literal comparison is not real logic, so the type string is compared in smali, with the literal as the receiver of `String.equals` (a null type is then safe). `hidepremium` stays free of `extendWith`.
- The patch `description` is unchanged: it already claims the upsells, and this change is what makes that claim true.

## Verified locally (LINE 26.11.0)

- `Disable LINE Premium` alone: `filterPremiumModules` present, ctor starts with the call, and the loop's three branches all land on instruction starts.
- **No regression on the two existing levers:** `e13.a.d()` and `vc4.k0.j()` still return false immediately, while `vc4.k0.q()` and `r()` are untouched — so the shape-based selection of `j()` still picks the right method.
- Composition: `+ Hide Home modules` gives two chained filters. With #70 merged into a throwaway branch, all **three** chain on the same ctor, then the original `Object.<init>` + `iput-object v1` into field `a`.
- Whole-dex branch-offset and try-block sweep clean on every APK (`badBranches=0 badTryOrHandler=0`).

**Not confirmed on device.** Static finding: `HomeTabLypRecommendation` never appeared in the on-device Home module capture from a Taiwan account (8 modules). The list is region- and server-driven, so this needs a tester whose account gets the upsell — same situation as the commerce tabs in #59 and the content feed in #69.

## Note on #70

#70's Home module inventory has a row marking `HomeTabLypRecommendation` as *not blocked, belongs to Disable LINE Premium*. That row needs a one-line update to say it is hidden now. Whichever of the two PRs merges second should carry that edit; I left `line-patch-map.md` untouched here so the two branches do not conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
