### PR TITLE
docs: Simple English pass over comments and reference maps

### DIFF
--- a/docs/line-patch-map.md
+++ b/docs/line-patch-map.md
@@ -6,7 +6,7 @@ Reference notes for authoring LINE (`jp.naver.line.android`) patches, distilled 
 > ⚠️ **Obfuscation drift.** Names like `hg1.d`, `az0.q`, `d00.z`, `ne1.y0$c`, `fg1.a$b`, `r51.a`
 > are R8-obfuscated and **change between LINE versions**. The concepts and anchoring strategies are
 > durable; re-confirm every descriptor against the decompiled smali on a version bump. Prefer
-> anchors obfuscation can't touch: Kotlin **enum-constant names** (`CALENDAR`, `GIFT`), **string
+> anchors obfuscation cannot touch: Kotlin **enum-constant names** (`CALENDAR`, `GIFT`), **string
 > literals**, **resource ids**.
 
 ---
@@ -65,14 +65,14 @@ true:
 1. **Static local tiles** — one `hg1.r` subclass each, constructed inline in `gg1.e.r()`.
 2. **Server-driven services** — a runtime-fetched list (`r11.d.c()` → `List<r51.a>`); each entry
    becomes one `hg1.d` (the single shared "ChatAppButtonType" class), built in the loop at
-   `gg1/e.smali:827`. If the list isn't cached yet it returns `[]` and kicks off an async fetch,
+   `gg1/e.smali:827`. If the list is not cached yet it returns `[]` and kicks off an async fetch,
    then re-renders.
 
 ### Item gates (`hg1.r` / `hg1.a`)
 
 `hg1.r.f(Lgi1/b;Lfg1/a;Lhg1/a$a;)Z` is the visibility gate. It shows an item only when: the chat
 type is in the item's allowed set **AND** `j(Lgi1/b;)Z` (per-type availability) **AND** `k(...)`
-**AND** `l(...)` all pass. So **forcing `j()` false hides a static tile**; forcing `f()` false hides
+**AND** `l(...)` all pass. So **forcing `j()` false hides a static tile**. Forcing `f()` false hides
 whatever class owns that `f()`.
 
 ### Static tiles (LINE 26.11.0)
@@ -107,13 +107,13 @@ icons and destinations all come from the server payload, **not** from local reso
 - **Hide one service (fragile — avoid):** a single service is identifiable only by its LINE service
   **channel id** (Schedule/create-event = `"1655112642"` real / `"1651805621"` beta, in enum
   `jg1.a$a.SCHEDULE` → `et1.s.g.SCHEDULE`). Channel ids are server-assigned and can change, so such a
-  patch can't be pinned to an APK version. Prefer the category gate.
+  patch cannot be pinned to an APK version. Prefer the category gate.
 
 ---
 
 ## LINE Calendar vs Events vs Message scheduler — three distinct features
 
-Easy to conflate; they are separate features with separate entry points, gates, and destinations.
+Easy to conflate. They are separate features with separate entry points, gates, and destinations.
 
 **Calendar** (native LINE Calendar; strings `line_calendar_*`; feature gate interface `jp0.d`, impl
 `pp0.g`). Five in-messenger entry points, all removed by **"Hide calendar buttons"**:
@@ -177,15 +177,15 @@ single slot. Two rules follow:
   the branch's trailing `goto`, so the slot stays empty, as stock LINE does when the gate is on.
 - **Anchor each patch on its own constants only.** The tab patches run in arbitrary order against one
   method and each fingerprint resolves *after* earlier mutations, so anchoring on a constant another
-  patch removes breaks the match. (Hence Hide Shopping tab avoids `TIMELINE` and `MINI`/`WALLET`; see
+  patch removes breaks the match. (Thus Hide Shopping tab avoids `TIMELINE` and `MINI`/`WALLET`; see
   also `hidevoomtab/Fingerprints.kt`.)
 
 **A missing tab is safe everywhere.** Tab→index lookups are `Math.max(list.indexOf(...), 0)`, clamping
-to Home (`jp/naver/line/android/activity/main/c.java`); `x66.d.a` only emits a `VoomSecondDepth`
+to Home (`jp/naver/line/android/activity/main/c.java`). `x66.d.a` only emits a `VoomSecondDepth`
 telemetry event and `qy4.f0` only writes the `ADDITIONAL_MAIN_TAB` pref. The layout carries a view per
 tab (`xy7.g` → `R.id.bnb_*`), so an absent entry never renders.
 
-**The commerce tabs are region-gated, so they can't be device-tested from TW** —
+**The commerce tabs are region-gated, so they cannot be device-tested from TW** —
 `function.maintab.commercetab` is server-pushed and off outside JP. Local proof stopped at
 disassembly: both pairs gone, `if-eqz`/`goto` skeletons and the `SQUARE`/`TIMELINE` pairs intact,
 whole-dex branch-offset sweep clean, all four tab patches coexisting under the full bundle. Then
@@ -261,7 +261,7 @@ singletons whose `getType()` returns a `static final` field, so a grep for the l
 
 Every type in the feed below the friends list starts with `HomeFeed` (network models `GcsHomeFeed*`,
 including `GcsHomeFeedScrollAffordance` — it is an infinite scroller). The server rotates between card
-variants, so a literal list reopens the hole on the next rotation; the extension tests
+variants, so a literal list reopens the hole on the next rotation. The extension tests
 `type.startsWith("HomeFeed")` instead. The error and loading placeholders are included on purpose, so
 no orphan spinner or error shell is left where the cards were.
 
@@ -287,7 +287,7 @@ never ran; `ENTER` with no per-type lines = empty list at that point; per-type l
 
 ### Finer discriminators, if a type string is ever too coarse
 
-`m52.z` carries more than the payload: `f229498a` = module id (e.g.
+`m52.z` carries more than the payload: `f229498a` = module id (for example
 `home-feed-module_home-feed-default-page-loading`; **LINE itself filters on it** at `an2/d.java:75`),
 `f229499b` = module name, `f229500c`/`f229501d` = timestamps, `f229502e` = the `m52.a0` payload,
 `f229503f` = ACI gate enum `m52.m0` (`DISABLED` / `ACI_REQUIRED` / `ALWAYS`), `f229504g` = upstream
@@ -328,7 +328,7 @@ unsent messages* carry extension code.
 
 ## LINE Pay intake & the "Redirect LINE Pay" patch
 
-**Why redirect instead of disable:** the messenger can't run its own Pay flow on a re-signed build
+**Why redirect instead of disable:** the messenger cannot run its own Pay flow on a re-signed build
 (the bundled VKey/V-Guard check fails — see `CLAUDE.md`). The patch (still packaged
 `line.disablepay`, object `disablePayPatch`) forwards the payment to the user's separately-installed
 **standalone LINE Pay app** — unpatched, so integrity passes — then closes the in-app Pay screen. A
@@ -352,7 +352,7 @@ merchant "LINE Pay" link  (line:// or https://line.me/R/…)
   (obfuscated `sv3.n`) for the real `https://web-pay.line.me/…` URL before loading it in a WebView.
 - `web-pay.line.me` / `web-tw-pay.line.me` / `/R/iab` are **not** literals in the APK or manifest —
   those hosts are server config. So an `ACTION_VIEW` for `https://web-tw-pay.line.me/R/iab?…` fired
-  from inside LINE is not caught by the messenger; it resolves to the standalone app.
+  from inside LINE is not caught by the messenger. It resolves to the standalone app.
 
 ### The redirect
 
@@ -367,7 +367,7 @@ The extension (`app/andrewliang/extension/LinePayRedirect.java`) reads the inten
   known-good web-pay url). Rebuilds
   `https://web-pay.line.me/web/payment/waitPreLogin?transactionReserveId=<reserveId>&locale=zh-TW_LP`.
 - an already-resolved `web-pay.line.me` url — used as-is.
-- anything else (e.g. `line://pay/main`) — no reserve id → **no redirect**, the activity just
+- anything else (for example `line://pay/main`) — no reserve id → **no redirect**, the activity just
   `finish()`es (a loop guard: never wrap a link that would round-trip back to the messenger).
 
 then fires
@@ -377,7 +377,7 @@ https://web-tw-pay.line.me/R/iab?url=<urlencoded inner web-pay url>
 ```
 
 with `FLAG_ACTIVITY_NEW_TASK`, swallowing all exceptions so `finish()` always runs. A token-free
-breadcrumb is logged under logtag **`AndrewLinePay`**; the single-use reserve id deliberately is not.
+breadcrumb is logged under logtag **`AndrewLinePay`**. The single-use reserve id deliberately is not.
 
 **Device-confirmed (LINE 26.11.0):** tapping a merchant "LINE Pay" button
 (`http://line.me/R/pay/payment/<reserveId>`) reaches **`PayLaunchActivity`** with
@@ -385,7 +385,7 @@ breadcrumb is logged under logtag **`AndrewLinePay`**; the single-use reserve id
 and the reconstruction opened the standalone app on the transaction. The `PayLiffActivity` hook is
 kept as defensive coverage for the `lpUsage=STANDALONE` route; if a future version routes there with
 no usable web url in the intent, reuse LINE's `r7()` resolver (anchor on the stable `"lpUsage"` /
-`"STANDALONE"` literals and read the obfuscated `l5()`/`r7()` descriptors from the matches — don't
+`"STANDALONE"` literals and read the obfuscated `l5()`/`r7()` descriptors from the matches — do not
 hardcode `sv3.n`, which drifts).
 
 ---
@@ -455,7 +455,7 @@ copying it and letting LINE tombstone the original — preserves its real `serve
 forwarding and reactions keep working on the kept message.
 
 The guard is located **by instruction shape** (no-arg `Z` call → `move-result` → `if-eqz` → `goto`) and
-the `SQLiteDatabase` field reference is read from the method's own bytecode, since `i38.c`, its `h()`
+the `SQLiteDatabase` field reference is read from the method's own bytecode, because `i38.c`, its `h()`
 and `g38.f3.b` all drift. The two register reads are anchored rather than scanned blind: the message id
 must be a field of the same row object the guard reads its receiver off, and the `SQLiteDatabase` holder
 register must carry a `check-cast` to the field's own owner before the guard (this method has a *second*
@@ -488,9 +488,9 @@ draw the notice twice.
 > 34 MB photo arrived at 24 MP instead of 1.64 MP, via five sites across two send paths plus an
 > extension), and then deliberately dropped.** Recorded so nobody re-derives it. Why it was dropped:
 >
-> - **Coverage can't match the promise.** It fixed the chatroom `+` / photo-strip flow only. Album is
+> - **Coverage cannot match the promise.** It fixed the chatroom `+` / photo-strip flow only. Album is
 >   unfixable without inflating every album upload (no "Original" button, below), share-to-LINE is a
->   third path never traced, and a user can't tell which entry point they used. A patch that silently
+>   third path never traced, and a user cannot tell which entry point they used. A patch that silently
 >   applies to some sends invites bug reports.
 > - **Maintenance is a re-investigation, not a fingerprint refresh.** Four fingerprints, one on a
 >   synthetic Kotlin lambda (`th1.t$c$b`) that reshuffles whenever its enclosing method changes — and
@@ -599,12 +599,12 @@ gallery-picker path and were never device-verified.
 The extension re-derived the same `>= 20 MB || >= 100 MP` test the sites removed and returned `null`
 otherwise, leaving every already-working case untouched — notably a 50 MP / 10 MB JPEG, which must
 keep being copied byte for byte. Output was bounded to 24 MP via `inSampleSize` plus
-`inScaled`/`inDensity`/`inTargetDensity`; the density scaler matters because `inSampleSize` alone
+`inScaled`/`inDensity`/`inTargetDensity`. The density scaler matters because `inSampleSize` alone
 quantises a 126 MP source to ~7.9 MP. Rotation was baked into the pixels rather than written as an
 EXIF tag, matching every other LINE encoder on this path.
 
 **Rotation must come from LINE, not from EXIF.** `c1.f(dVar, fVar, uri, Integer rotation)` hands
-the *same* `Integer` to `c1.p` (the standard variant, hence the thumbnail and OBS's `/preview`) and to
+the *same* `Integer` to `c1.p` (the standard variant, so the thumbnail and OBS's `/preview`) and to
 the `y0` lambda. Both prefer it and fall back to the file's EXIF (`c1.d(uri)`, an `ExifInterface`
 "Orientation" read) only when it is `null`. So the patch passed the lambda's `Ljava/lang/Integer;`
 capture (`y0.c`) in with EXIF as fallback only: deriving from EXIF unconditionally leaves the original
@@ -630,7 +630,7 @@ types were hardcoded.
 Freeing the incoming-call ringtone from LINE's four bundled tones / paid Melody Shop tones is
 **technically patchable**: the decision is entirely client-side and the playback layer already accepts
 an arbitrary `Uri`. Nothing shipped — the reason is product value, not feasibility, see
-[Why nothing shipped](#why-nothing-shipped). Recorded so it isn't re-derived.
+[Why nothing shipped](#why-nothing-shipped). Recorded so it is not re-derived.
 
 ### The choke point
 
@@ -662,7 +662,7 @@ then `setAudioAttributes(USAGE_NOTIFICATION_RINGTONE)`, `setLooping(true)`, `pre
 
 This is what makes it patchable: the URI is opened **inside LINE's process**, never handed to the
 system NotificationManager, so the cross-process permission problems that sink the Google sign-in
-limitation don't apply. (Message *notification* sounds are a separate system — ordinary Android
+limitation do not apply. (Message *notification* sounds are a separate system — ordinary Android
 notification channels, already customisable in system Settings.)
 
 ### What actually limits users today
@@ -677,7 +677,7 @@ int, `k97.m.m()` → `vb7.c.m()` → `t().G0().l().e()`:
 | `2` | fall through to the region switch below |
 
 Only when it is `2` does region matter (`s87.i.a()`), and the premium branches additionally require
-`a.b()` — all three of `k97.m.s()` / `.f()` / `.r()` non-empty, i.e. the premium-service URLs are
+`a.b()` — all three of `k97.m.s()` / `.f()` / `.r()` non-empty, that is the premium-service URLs are
 configured:
 
 | Region | Provider | Ringtone setting visible? |
@@ -688,7 +688,7 @@ configured:
 | everywhere else | `DEFAULT` | **no** |
 
 Only MUSIC / MELODY / FRIEND_MELODY set `exposeExternalSetting = true`, which is what makes the
-"Ringtones & ringback tones" entry appear. `DEFAULT` hardcodes `ue7.a.RING_1`; `EMBEDDED` resolves
+"Ringtones & ringback tones" entry appear. `DEFAULT` hardcodes `ue7.a.RING_1`. `EMBEDDED` resolves
 through `ge7.c.e(m87.h.RING)`, reading the *legacy* melody prefs and falling back to `RING_1` when
 empty. **So outside JP/TH/TW there is no ringtone choice in the UI at all** — not even among the four
 bundled tones, reachable only under JP's `MUSIC` provider (it alone reads the `cf7.m` prefs). The
@@ -702,7 +702,7 @@ back to `RING_1`. Head-injecting `be7.c.a` sits ahead of all of this.
 
 ### Tone inventory and storage
 
-`ue7.a` is the bundled-tone enum; ids take the form `android.resource:///<id>`.
+`ue7.a` is the bundled-tone enum. Ids take the form `android.resource:///<id>`.
 
 | Constant | `res/raw` | Title |
 |---|---|---|
@@ -712,7 +712,7 @@ back to `RING_1`. Head-injecting `be7.c.a` sits ahead of all of this.
 | `RING_4` | `ring` | Telephone ring |
 | `RINGBACK_1` | `lineapp_ringback_16k` | — |
 
-Two parallel storage systems, both **encrypted** and therefore not readable from an extension:
+Two parallel storage systems, both **encrypted**, and so not readable from an extension:
 
 - **Current** — `jp.naver.voip.ringtone` via `cf7.m` (keys `ringToneUri`, `ringToneName`,
   `ringToneResourceTypeId`, `ringToneDecodedUriFlag`; accessors `cf7.p.a` / `cf7.p.b`). Built by
@@ -808,10 +808,10 @@ identity login (it also carries `apple_login_code_result_key`), shared by Google
 
 ### Path 1 is not patchable
 
-LINE asks the platform for a credential; `system_server` enumerates registered providers and picks
+LINE asks the platform for a credential. `system_server` enumerates registered providers and picks
 Google's `…credman.service.GoogleIdService`. LINE never names Play Services, so there is **no package,
 action or string in the APK to rewrite**, and MicroG-RE implements the *GMS* Credentials API but not
-`android.service.credentials.CredentialProviderService`, so it can't be offered as a provider either.
+`android.service.credentials.CredentialProviderService`, so it cannot be offered as a provider either.
 Device log:
 
 ```
@@ -844,8 +844,8 @@ previous stopped failing. Expect the same if it regresses: fix one, re-test, fin
 **Site 2 needs code, not a string.** `setSelectedAccountName` resolves the picked name by scanning
 `AccountManager.getAccountsByType(type)`, which can never work for a GmsCore account: since Android 8
 an authenticator controls account **visibility**, and GmsCore grants it on its first `setAuthToken` —
-i.e. *after* a token, which needs the account to resolve first. The scan returns empty, both fields
-stay null, and LINE re-prompts forever. The patch builds the `Account` directly from the name; the
+that is, *after* a token, which needs the account to resolve first. The scan returns empty, both fields
+stay null, and LINE re-prompts forever. The patch builds the `Account` directly from the name. The
 scan only ever existed to turn a name into an `Account`.
 
 Guard **both** null and empty string, branching into the original body: LINE calls
@@ -859,7 +859,7 @@ a search for `""` matched nothing.
 **only the package half**: MicroG-RE ships `applicationId app.revanced.android.gms` but keeps
 `namespace com.google.android.gms`, so its `<service android:name=".auth.GetToken">` really is the
 class `com.google.android.gms.auth.GetToken` inside the `app.revanced` package. Rewriting the class
-name too binds a component that doesn't exist — LINE shows a generic access error with **nothing in
+name too binds a component that does not exist — LINE shows a generic access error with **nothing in
 the log**, because no service starts.
 
 Everything else keeps talking to real Play Services — Maps, location sharing, ML Kit, FCM, anything
@@ -898,7 +898,7 @@ The order is the trap. `PackageUtils.getAndCheckPackage()` spoofs the caller's *
 - If the spoofed package is absent, `getPackageInfo` throws and the code falls back to
   `KNOWN_GOOGLE_PACKAGES` (Google's apps only) → `client_sig` goes out **null**. This is why the
   ReVanced flow works for YouTube/Photos and would not for LINE.
-- Therefore the patch **must keep LINE's package name**. The rename the YouTube/Photos GmsCore
+- Thus the patch **must keep LINE's package name**. The rename the YouTube/Photos GmsCore
   patches perform would silently defeat the override.
 - GmsCore targets **SDK 29**, so package-visibility filtering does not apply to it. A
   `targetSdk 30+` app needs a `<queries>` entry to see it at all.
@@ -932,8 +932,8 @@ needed anyway — real Play Services is installed, so the "GMS missing" checks n
 
 **Extend the unsend window.** The client windows (`j51.a.o` free, `.p` premium) are UX pre-filters fed
 by server config (`function.chatroom.message.unsend.timelimit`, `.premium.timelimit`). `unsendMessage`
-carries only `(seq, messageId)`; the server decides, with a dedicated `TalkException` code
-`MESSAGE_NOT_DESTRUCTIBLE(71)` (`cb8.m9`) handled at `ne1.o2` / `ne1.b2` → *"You can't unsend this
+carries only `(seq, messageId)`. The server decides, with a dedicated `TalkException` code
+`MESSAGE_NOT_DESTRUCTIBLE(71)` (`cb8.m9`) handled at `ne1.o2` / `ne1.b2` → *"You cannot unsend this
 message as too much time has passed."* Widening the client window only re-shows the menu item and
 produces that toast. (`hidepremiumunsend` narrows it for the same reason.)
 

--- a/docs/line-premium-map.md
+++ b/docs/line-premium-map.md
@@ -5,8 +5,8 @@ Reference notes on how **LINE Yahoo Premium (LYP)** feature-gating works in LINE
 `app/andrewliang/patches/shared/Constants.kt`). Companion to `docs/line-patch-map.md`.
 
 > ⚠️ **Obfuscation drift.** Names like `b13.l`, `z03.b`, `t13.i/k/n/b/q` are R8-obfuscated and
-> **change between LINE versions**; re-confirm every descriptor on a version bump. Prefer anchors
-> obfuscation can't touch: **string literals** (`"LITE_ENJOY"`), framework types
+> **change between LINE versions**. Re-confirm every descriptor on a version bump. Prefer anchors
+> obfuscation cannot touch: **string literals** (`"LITE_ENJOY"`), framework types
 > (`Ljava/lang/Boolean;`, `Lkotlin/coroutines/Continuation;`), Thrift op-name literals.
 
 ---
@@ -21,7 +21,7 @@ Reference notes on how **LINE Yahoo Premium (LYP)** feature-gating works in LINE
    that re-verifies entitlement independently. The client status is a read-model, not the gate.
 
 **Net:** a blanket "unlock premium" is not achievable. Flipping the client gate can at most surface UI or
-enable purely-local behavior; server-delivered or authorized content stays enforced.
+enable purely-local behavior. Server-delivered or authorized content stays enforced.
 
 ---
 
@@ -41,9 +41,9 @@ current `LypUserStatus` **is** `Subscribed` (`instance-of Lt13/i$b;`) **AND** pr
 
 | Accessor | Returns | Role | Caller count |
 |---|---|---|---|
-| `u(Feature, Continuation)` | boxed `Boolean` | per-feature boolean gate | ~18 (e.g. `SUBPROFILE`, `MESSAGE_EDIT`, backup/gallery/migration) |
+| `u(Feature, Continuation)` | boxed `Boolean` | per-feature boolean gate | ~18 (for example `SUBPROFILE`, `MESSAGE_EDIT`, backup/gallery/migration) |
 | `s(Feature, Continuation)` | `t13.k` | per-feature status object (`k.a()Z` = "is restricted/not offered") | dominant path for `APP_ICON`, `FONT` |
-| `A(Feature, Continuation)` | `t13.n` | per-feature params object | e.g. `APP_ICON`, `FONT` |
+| `A(Feature, Continuation)` | `t13.n` | per-feature params object | for example `APP_ICON`, `FONT` |
 | `o()` | `t13.i` (`LypUserStatus`) | synchronous raw status read; callers do their own `instanceof i$b` | 38 |
 | `a(Continuation)` | `t13.i` | suspend raw status read | 33 |
 | `q()` | `StateFlow<t13.i>` | reactive status | — |
@@ -111,7 +111,7 @@ non-obfuscated class refs inside `b13.l` (`LypPremiumSubscriptionActivity`,
 ## Unlocking is not viable (tested)
 
 Forcing the client gate `b13.l.u(Feature) -> Boolean` to `true` was built and **tested on device — it
-unlocks nothing**, confirming the analysis. That experimental patch was **dropped**. Why it can't work:
+unlocks nothing**, confirming the analysis. That experimental patch was **dropped**. Why it cannot work:
 
 - Features gated through the object-returning `s()`/`A()` accessors (`APP_ICON`, `FONT`) or read straight
   off raw status via `o()`/`a()` are never reached by a `u()` flip, and forcing `s()`/`A()` to a boolean
@@ -125,11 +125,11 @@ So the practical direction is **hiding** premium, not unlocking it.
 
 ## Disabling premium (this bundle: `Disable LINE Premium`)
 
-Since premium can't be unlocked, `Disable LINE Premium` **hides every premium surface** — upsell
+Because premium cannot be unlocked, `Disable LINE Premium` **hides every premium surface** — upsell
 popups/banners, badges/locks, the "LINE Premium" settings page and its entry rows, the subscribe/manage
 flows — by forcing LINE's own market-availability flag off.
 
-**Master lever:** `e13.a.d()Z` (`return a().W()`, i.e. `jw4.i1.W()`) — the config bit meaning "LYP
+**Master lever:** `e13.a.d()Z` (`return a().W()`, that is `jw4.i1.W()`) — the config bit meaning "LYP
 premium is available in this market". The facade reads it three ways that **all cascade from `d()`**:
 
 | Facade read | Derivation | Effect when `d()` = false | Consumers |
@@ -148,14 +148,14 @@ server flags that ship enabled alongside `d()`. One of each combined into a cras
 [Second lever](#second-lever-the-premium-backup-flag-required).
 
 **Premium-scoped:** `e13.a.d()` has only 4 direct callers, all in the premium module. The shared
-underlying `jw4.i1.W()` is read directly by 6 non-premium features (profile, etc.) — those are
+underlying `jw4.i1.W()` is read directly by 6 non-premium features (profile, and more) — those are
 **not** touched (the patch neuters `e13.a.d()`, not `i1.W()`).
 
 **Anchoring (nothing obfuscated hardcoded):** find facade `b13.l` via the unique `"LITE_ENJOY"` string,
 then its `z()` accessor — uniquely the parameterless `()Z` with exactly two `invoke-virtual`s
 (`return H().d()`; siblings `h()`/`y()`/`B()` have four) — and take the 2nd call's `MethodReference` to
 resolve `e13.a.d()` at apply time. Verified on 26.11.0: only `e13.a.d()` is rewritten (to
-`const/4 v0,0x0` / `return v0`); the facade is untouched.
+`const/4 v0,0x0` / `return v0`). The facade is untouched.
 
 **Not covered / follow-up:** a secondary market bit `jw4.m2…a().U().O()` gates a couple of surfaces
 (album promo, app-icon seasonal) independently of `e13.a.d()`. If any premium surface survives on
@@ -165,7 +165,7 @@ LINE version.
 ### Second lever: the premium-backup flag (required)
 
 **Symptom:** on a patched build, **Settings ▸ Chats** threw and bounced back to Home. Stock is fine;
-reproduced on both Standard (re-signed) and Root Mount, i.e. signing-independent. Caused by
+reproduced on both Standard (re-signed) and Root Mount, that is signing-independent. Caused by
 `Disable LINE Premium` alone.
 
 **Chain** (all verified against decompiled 26.11.0):
@@ -191,16 +191,16 @@ every sibling null-guards (`ux4/a0.java:73`, `ux4/d0.java:89`, `ux4/c0.java:123,
 `if (num != null) … getDrawable(num.intValue())`). The other two `px4.c1` badge rows are fine: Settings ▸
 Friends by inspection (provider `p05.b` returns the constant `R.drawable.lyp_premium_label`), and
 Settings ▸ Albums **by device test** — its provider `::providePremiumBadgeResId`
-(`settings/albums/a.java:237`) is nullable with an obfuscated target, so it couldn't be read statically,
-but that screen opened fine on the *unfixed* build, i.e. with the market gate already off. That is the
+(`settings/albums/a.java:237`) is nullable with an obfuscated target, so it could not be read statically,
+but that screen opened fine on the *unfixed* build, that is with the market gate already off. That is the
 exact triggering condition, so the Albums provider never returns null here and there is no second null
-source. **Don't re-investigate it.**
+source. **Do not re-investigate it.**
 
 **Fix (shipped, device-confirmed 2026-08-20 on LINE 26.11.0):** also force the premium-backup gate
 `ic4.d.j()` (impl `vc4.k0.j()`) to `false`. The gate is used **complementarily** in the settings UI —
 `chats/a.java:880` shows the premium row on `j()`, `chats/a.java:303` shows the ordinary **"Back up chat
 history"** row on `!j()` — so `false` hides the crashing row *and* restores a working non-premium backup
-entry (a `px4.i1`, not a badge row, so it can't reach `getDrawable`). All 8 call sites
+entry (a `px4.i1`, not a badge row, so it cannot reach `getDrawable`). All 8 call sites
 (`j25/u2.java:1388,1619,1817`, `lz4/t.java:216,242`, `chats/a.java:303,730,880`) are premium-vs-classic
 backup UI gating, so `false` degrades cleanly everywhere — device-checked: Settings ▸ Chats opens with
 the ordinary backup row, and every other settings screen (main list, Albums, Friends) is unaffected.
@@ -253,7 +253,7 @@ region-driven and server-driven, so this needs a tester whose account gets the u
 
 ### Known survivors: premium unsend upsells (patch `Hide premium unsend upsells`)
 
-Two premium-unsend surfaces read config directly, bypassing `e13.a.d()`, so the master lever doesn't
+Two premium-unsend surfaces read config directly, bypassing `e13.a.d()`, so the master lever does not
 hide them — a supplementary patch does:
 
 - **"Unsend discreetly" button** in `UnsendMessageLdsDialog.onViewCreated` (shown only for the
@@ -262,12 +262,12 @@ hide them — a supplementary patch does:
   on the unique string id `0x7f150bff`: (a) force the guarding `instance-of` false so `n3()`/`o3()`
   take the hide branch; (b) `setVisibility(GONE)` on the green button `r3()` inside its
   `if (r3() != null)` guard. `r3()` exists only in the silent dialog —
-  `NormalUnsendMessageLdsDialog.r3()` returns `null` — so this can't affect the ordinary dialog, and
+  `NormalUnsendMessageLdsDialog.r3()` returns `null` — so this cannot affect the ordinary dialog, and
   the silent dialog keeps its working "Unsend" (`p3()`) and "Close" (`m3()`) buttons.
 - **"How to unsend discreetly" promo link** built in the `wi1.j4` constructor, gated on
   `ne1.k2.a(i1.W() && i1.X(), …) == SUPPORTED_CHAT`. `i1.W()` is the shared bit `e13.a.d()` wraps,
   read here directly (one of the 7 non-`e13.a` `i1.W()` readers). Anchored via the unique promo
-  string id `0x7f150bf8` → class `wi1.j4`; the `k2.a` first argument is forced false so the link
+  string id `0x7f150bf8` → class `wi1.j4`. The `k2.a` first argument is forced false so the link
   handler stays null. Obfuscated `Lne1/k2;` drifts — re-verify on version bump.
 - **"Unsend" menu item for messages past the free window** — the biggest upsell ("Give yourself more
   time to delete messages you sent") is reached only by tapping the long-press "Unsend" item on a
@@ -280,4 +280,4 @@ hide them — a supplementary patch does:
   unsend within ~1h is unaffected. Anchored on `fieldAccess(Lj51/a;, p)` (the target read) + the
   readable enum `Lj51/c;->PREMIUM_UNSEND_MESSAGE` (disambiguator; obfuscated `Lj51/a;`/`Lj51/c;`/`p`/`o`
   drift — re-verify on version bump). Note: a premium subscriber applying the bundle also loses 1h–7d
-  unsend; for a non-premium user nothing is lost (those messages were never free-unsendable anyway).
+  unsend. For a non-premium user nothing is lost (those messages were never free-unsendable anyway).

--- a/extensions/extension/src/main/java/app/andrewliang/extension/KeepUnsentMessages.java
+++ b/extensions/extension/src/main/java/app/andrewliang/extension/KeepUnsentMessages.java
@@ -50,7 +50,7 @@ public final class KeepUnsentMessages {
      * <p>{@code created_time} is a TEXT column of epoch millis, so the +1 that orders the placeholder
      * directly below its message needs a cast round-trip. Ordering follows {@code created_time} (the
      * {@code IDX_CHAT_ID_ID_CREATED_TIME} sort columns), so the notice lands under the message rather
-     * than at the end of the conversation; one millisecond is invisible at the UI's minute precision.
+     * than at the end of the conversation. One millisecond is invisible at the UI's minute precision.
      *
      * <p>{@code status}, {@code read_count} and {@code sent_count} are inherited so the notice carries
      * the same read receipt as the message it annotates. They are <em>not</em> what the chat list's
@@ -94,7 +94,7 @@ public final class KeepUnsentMessages {
      * @param messageId the unsent message's id — whichever of the row's two long ids is already
      *                  loaded at the patch site, so either the local {@code chat_history.id} or the
      *                  {@code server_id}. The statement matches on either; local ids are small and
-     *                  server ids large, so the spaces don't realistically overlap, and
+     *                  server ids large, so the spaces do not realistically overlap, and
      *                  {@code LIMIT 1} bounds it regardless.
      */
     public static void insertPlaceholder(SQLiteDatabase db, long messageId) {

--- a/extensions/extension/src/main/java/app/andrewliang/extension/LinePayRedirect.java
+++ b/extensions/extension/src/main/java/app/andrewliang/extension/LinePayRedirect.java
@@ -73,7 +73,7 @@ public final class LinePayRedirect {
     }
 
     /**
-     * Turn an incoming pay deep link into the standalone web-payment url, or null if it isn't a
+     * Turn an incoming pay deep link into the standalone web-payment url, or null if it is not a
      * recognizable payment link. Handles:
      *   - an already-resolved web-pay page (returned as-is)
      *   - {@code .../pay/payment/<reserveId>} deep links (http(s)://line.me/R/... or line://pay/...)

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/chatheaderbuttons/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/chatheaderbuttons/Fingerprints.kt
@@ -7,22 +7,22 @@ import app.morphe.patcher.methodCall
 private const val BUTTON_ENUM = "Laz0/q;"
 
 /**
- * The Chats-tab header button set is built in the ChatTabHeaderStateImpl constructor
- * (obfuscated), which adds each button as `sget-object <az0.q constant>` + `add(...)` to the
- * button list. The button enum constant names (OPEN_CHAT, CALENDAR, …) are non-obfuscated
- * (Kotlin enum names survive), so we anchor on them.
+ * The ChatTabHeaderStateImpl constructor (obfuscated) builds the Chats-tab header button set.
+ * It adds each button to the button list as `sget-object <az0.q constant>` + `add(...)`. The
+ * button enum constant names (OPEN_CHAT, CALENDAR, …) are non-obfuscated, because Kotlin enum
+ * names survive, so we anchor on them.
  *
- * The fingerprint matches its enum constant's `sget-object` immediately followed by the list
- * `add` call — that pair uniquely lands in the constructor (the enum's WhenMappings table
- * accesses the same constants but follows them with `ordinal()`, not `add`). The Chats-tab
- * header calendar button is anchored the same way from the `hidecalendar` package, so the two
- * patches don't depend on each other and work in either order when both are enabled.
+ * The fingerprint matches its enum constant's `sget-object` followed at once by the list
+ * `add` call. That pair lands only in the constructor. The enum's WhenMappings table reads the
+ * same constants, but follows them with `ordinal()`, not `add`. The `hidecalendar` package
+ * anchors the Chats-tab header calendar button the same way. Thus the two patches do not depend
+ * on each other and work in either order when both are on.
  */
-// The header button list is a `fb8/b` (the `add` calls target `Lfb8/b;`). The `add`'s
-// definingClass is pinned to disambiguate from the green-dot icon set (ChatTabHeaderStateImpl
-// $greenDotVisibleIconSet), which references the same OPEN_CHAT constant but adds to a
-// different list class (`fb8/j`) — without this, OPEN_CHAT + add could silently match the
-// green-dot method instead of the header builder.
+// The header button list is a `fb8/b` (the `add` calls target `Lfb8/b;`). Pinning the `add`'s
+// definingClass separates it from the green-dot icon set (ChatTabHeaderStateImpl
+// $greenDotVisibleIconSet), which reads the same OPEN_CHAT constant but adds to a different
+// list class (`fb8/j`). Without this pin, OPEN_CHAT + add could silently match the green-dot
+// method instead of the header builder.
 private const val HEADER_LIST_ADD = "Lfb8/b;"
 
 internal object CommunityButtonFingerprint : Fingerprint(

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/chatheaderbuttons/HideCommunityButtonPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/chatheaderbuttons/HideCommunityButtonPatch.kt
@@ -12,9 +12,9 @@ val hideCommunityButtonPatch = bytecodePatch(
 ) {
     compatibleWith(COMPATIBILITY_LINE)
 
-    // Remove the `sget-object OPEN_CHAT` + following `add(...)` pair so the button is never
-    // added to the header list. instructionMatches[0] = the OPEN_CHAT sget-object; the add is
-    // the immediately-following instruction.
+    // Remove the `sget-object OPEN_CHAT` + following `add(...)` pair so nothing adds the button
+    // to the header list. instructionMatches[0] = the OPEN_CHAT sget-object. The add is the
+    // next instruction.
     execute {
         val openChatSgetIndex = CommunityButtonFingerprint.instructionMatches.first().index
         CommunityButtonFingerprint.method.removeInstructions(openChatSgetIndex, 2)

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/externalbrowser/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/externalbrowser/Fingerprints.kt
@@ -6,13 +6,13 @@ import app.morphe.patcher.methodCall
 /**
  * `com.linecorp.browser.OpenUriActivity$b.a(...)` — the single Intent builder for opening a
  * URL. For http/https URLs it switches on the `OpenUriActivity$a` browser-mode parameter to
- * decide Custom Tab vs in-app WebView vs external. By overwriting that mode parameter with
- * `EXTERNAL_WITHOUT_CUSTOMTABS`, every web-URL open is routed into LINE's own native
+ * decide Custom Tab vs in-app WebView vs external. Overwriting that mode parameter with
+ * `EXTERNAL_WITHOUT_CUSTOMTABS` routes every web-URL open into LINE's own native
  * external-browser path (which has its own ActivityNotFoundException fallback). Non-web
- * schemes skip the mode switch entirely, so LIFF / line:// / tel: are unaffected.
+ * schemes skip the mode switch, so LIFF / line:// / tel: do not change.
  *
  * Non-obfuscated class + a distinctive signature (returns Intent, takes the OpenUriActivity$a
- * mode); the `$b.b(Uri)` web-gate call is used as an extra anchor.
+ * mode). The `$b.b(Uri)` web-gate call is used as an extra anchor.
  */
 internal object OpenUriIntentBuilderFingerprint : Fingerprint(
     definingClass = "Lcom/linecorp/browser/OpenUriActivity\$b;",

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/externalbrowser/ForceExternalBrowserPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/externalbrowser/ForceExternalBrowserPatch.kt
@@ -15,8 +15,8 @@ val forceExternalBrowserPatch = bytecodePatch(
 
     // Overwrite the OpenUriActivity$a mode parameter (p3) with EXTERNAL_WITHOUT_CUSTOMTABS at
     // method entry, so the web-URL branch routes into LINE's own native external-browser path.
-    // p3 is only read afterward by a null-check (our constant is non-null) and the mode
-    // switch; non-web URLs skip the switch, so they're unaffected. No coroutine, no extension.
+    // After that, only a null-check reads p3 (our constant is non-null) and the mode switch
+    // reads it. Non-web URLs skip the switch, so they do not change. No coroutine, no extension.
     execute {
         OpenUriIntentBuilderFingerprint.method.addInstructions(
             0,

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/fixpushnotifications/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/fixpushnotifications/Fingerprints.kt
@@ -7,14 +7,14 @@ import app.morphe.patcher.string
 /**
  * The Firebase Installations (FIS) request builder — obfuscated `ct.c.c(URL, String)`.
  *
- * This is the in-app method that assembles the HTTPS request LINE's bundled Firebase
- * Installations SDK sends to `firebaseinstallations.googleapis.com` to mint an installation /
- * FCM token. It self-reports the app's signing-certificate SHA-1 in the `X-Android-Cert`
- * header (computed from `PackageManager.GET_SIGNATURES` via `rl.a.a` → SHA-1 → uppercase hex
- * in `rl.h.b`). Google's API-key "Android apps" restriction validates that
- * `X-Android-Package` + `X-Android-Cert` pair against LINE's official cert without proving key
- * possession, so a re-signed build is rejected (`FisError: BAD CONFIG`) and never gets a push
- * token — hence no notifications when the app is fully closed.
+ * This in-app method assembles the HTTPS request that LINE's bundled Firebase Installations
+ * SDK sends to `firebaseinstallations.googleapis.com` to mint an installation / FCM token. It
+ * self-reports the app's signing-certificate SHA-1 in the `X-Android-Cert` header (computed
+ * from `PackageManager.GET_SIGNATURES` via `rl.a.a` → SHA-1 → uppercase hex in `rl.h.b`).
+ * Google's API-key "Android apps" restriction validates the `X-Android-Package` +
+ * `X-Android-Cert` pair against LINE's official cert, and does not prove key possession. Thus
+ * Google rejects a re-signed build (`FisError: BAD CONFIG`), and the build never gets a push
+ * token. As a result, there are no notifications when the app is fully closed.
  *
  * Anchored on the non-obfuscated `X-Android-Cert` header string plus the immediately following
  * `URLConnection.addRequestProperty` call (the site that sends the cert hash). The

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/fixpushnotifications/FixPushNotificationsPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/fixpushnotifications/FixPushNotificationsPatch.kt
@@ -12,12 +12,12 @@ import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
  *
  * `base.apk` (26.11.0) is signed with APK Signature Scheme v3.1 key rotation, so it carries two
  * certificates: the lineage-ROOT / original key (Android SDK 24–32) and a rotated key (SDK
- * 33+). `rl.a.a` reads the cert via the deprecated `GET_SIGNATURES`, which for a rotated app
- * returns the ORIGINAL (lineage-root) certificate for backward compatibility — so this is the
+ * 33+). `rl.a.a` reads the cert via the deprecated `GET_SIGNATURES`. For a rotated app, it
+ * returns the ORIGINAL (lineage-root) certificate for backward compatibility, so this is the
  * SDK 24–32 signer.
  *
  * If a re-signed build still shows `FisError: "BAD CONFIG"` after applying this patch, the
- * device may be reporting the rotated signer instead; swap in the SDK 33+ cert:
+ * device may be reporting the rotated signer instead. Then swap in the SDK 33+ cert:
  * `6A2927D945AEA6571E1DA5566802F25045D367BD`.
  */
 private const val LINE_ORIGINAL_CERT_SHA1 = "89396DC419292473972813922867E6973D6F5C50"
@@ -34,10 +34,10 @@ val fixPushNotificationsPatch = bytecodePatch(
     // The FIS request builder loads `const-string "X-Android-Cert"` then calls
     // `addRequestProperty(key, value)` where `value` holds the runtime-computed cert hash.
     // Overwrite that value register with LINE's original cert hash right before the call, so a
-    // re-signed build reports the allow-listed SHA-1. Only this FIS call site is touched; the
-    // shared `rl.a`/`rl.h` helpers (also used by Remote Config) are left intact.
+    // re-signed build reports the allow-listed SHA-1. This patch touches only this FIS call
+    // site. The shared `rl.a`/`rl.h` helpers (also used by Remote Config) stay intact.
     execute {
-        // instructionMatches[1] is the `addRequestProperty` invoke for X-Android-Cert; its
+        // instructionMatches[1] is the `addRequestProperty` invoke for X-Android-Cert. Its
         // value argument is registerE ({connection, key, value}). Reading it avoids hardcoding
         // the register, which can drift between versions.
         val addRequestProperty = FisRequestBuilderFingerprint.instructionMatches[1]

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/gmscoreauth/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/gmscoreauth/Fingerprints.kt
@@ -98,7 +98,7 @@ internal object AuthUtilConstantsFingerprint : Fingerprint(
  *
  * Not on the `getToken` path, which binds by ComponentName (see [AuthUtilConstantsFingerprint]),
  * but it is the generic auth binder and was part of the build confirmed working on device.
- * Retained for that reason; trimming it is untested.
+ * Retained for that reason. Trimming it is untested.
  */
 internal object AuthServiceActionFingerprint : Fingerprint(
     returnType = "Ljava/lang/String;",

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/gmscoreauth/GmsCoreAuthPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/gmscoreauth/GmsCoreAuthPatch.kt
@@ -161,7 +161,7 @@ val gmsCoreAuthPatch = bytecodePatch(
         // region account selection
 
         // Matches are, in program order: drive.appdata scope, allowable account type, picker
-        // action, target package. The scope is only an anchor; the other three all move.
+        // action, target package. The scope is only an anchor. The other three all move.
         AccountPickerIntentFingerprint.apply {
             rewriteString(1, MICROG_ACCOUNT_TYPE)
             rewriteString(2, MICROG_CHOOSE_ACCOUNT_ACTION)
@@ -175,10 +175,10 @@ val gmsCoreAuthPatch = bytecodePatch(
         // ...but the type alone is not enough — this is what sent the first device test back to the
         // picker with no token ever requested. Since Android 8 an authenticator controls account
         // *visibility*: `getAccountsByType` returns only accounts the caller was granted, and
-        // GmsCore grants that on its first `setAuthToken` — i.e. after a token, which needs the
+        // GmsCore grants that on its first `setAuthToken` — that is, after a token, which needs the
         // account to resolve first. The lookup returns empty, both fields stay null, LINE re-prompts.
         //
-        // Break the circle by building the Account straight from the name the picker returned; the
+        // Break the circle by building the Account straight from the name the picker returned. The
         // search only ever existed to turn a name into an Account.
         //
         // Null AND empty string must branch into the original body, which clears the fields: LINE
@@ -238,7 +238,7 @@ val gmsCoreAuthPatch = bytecodePatch(
         //
         // Not on the getToken path (that binds by ComponentName above), but it is the auth client
         // the rest of the GMS auth surface uses and was part of the device-confirmed build.
-        // Retained for that reason; trimming it is untested.
+        // Retained for that reason. Trimming it is untested.
 
         /**
          * The obfuscated name of `BaseGmsClient.getStartServicePackage()`, found by walking up from

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hideadviews/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hideadviews/Fingerprints.kt
@@ -10,7 +10,7 @@ import app.morphe.patcher.methodCall
  * list banner view and addViews it into the host FrameLayout (p1). Hiding that host once at
  * construction collapses the empty banner strip regardless of the banner's visibility state
  * (the previous `dispatchDraw` hook never fired while the strip was an empty placeholder).
- * `rb0/e` is obfuscated; anchored on the class + the non-obfuscated FrameLayout/`u0` params.
+ * `rb0/e` is obfuscated. Anchored on the class + the non-obfuscated FrameLayout/`u0` params.
  */
 internal object SmartChannelControllerFingerprint : Fingerprint(
     definingClass = "Lrb0/e;",

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hideadviews/HideAdViewsPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hideadviews/HideAdViewsPatch.kt
@@ -48,12 +48,12 @@ val hideAdViewsPatch = bytecodePatch(
         // Chat-list Smart Channel banner: hide its host container at controller construction.
         SmartChannelControllerFingerprint.method.addInstructions(0, HIDE_HOST)
 
-        // LINE Ads SDK display ads (Home/Wallet/etc.): self-collapse at onAttachedToWindow.
+        // LINE Ads SDK display ads (Home, Wallet, and more): self-collapse at onAttachedToWindow.
         LadAdViewFingerprint.method.addInstructions(0, HIDE_SELF)
         LyadAdViewFingerprint.method.addInstructions(0, HIDE_SELF)
 
         // Google AdManager wrappers — BEST-EFFORT. Obfuscated names drift across versions,
-        // so skip silently if not found; can never break the robust hiding above. Inject
+        // so skip silently if not found. It can never break the robust hiding above. Inject
         // setVisibility(GONE) on self right AFTER the super <init> call.
         val adManagerWrappers = listOf(
             AdManagerBannerChatroomFingerprint to HIDE_SELF_CTOR_V0,

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hideattachmenutools/HideAttachMenuExtraToolsPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hideattachmenutools/HideAttachMenuExtraToolsPatch.kt
@@ -17,8 +17,8 @@ val hideAttachMenuExtraToolsPatch = bytecodePatch(
     // Every server-driven attach service is rendered by the shared class hg1.d, shown only when its
     // per-item gate f(...) returns true. hg1.d is the sole renderer of these services, so forcing
     // its f() to unconditionally return false drops the entire set — with no dependency on any
-    // server channel id (the reason a single-service patch can't be stable). p0 is `this`;
-    // clobbering it is fine since we return immediately.
+    // server channel id (the reason a single-service patch cannot be stable). p0 is `this`;
+    // clobbering it is fine because we return immediately.
     execute {
         AttachMenuServiceGateFingerprint.method.addInstructions(
             0,

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidecalendar/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidecalendar/Fingerprints.kt
@@ -8,11 +8,11 @@ import app.morphe.patcher.methodCall
 /**
  * Fingerprints for every LINE Calendar button in the messenger: the Chats-tab header
  * ([CalendarButtonFingerprint]) plus four inside a chat room (top toolbar, "+" attach menu,
- * slide-out chat menu, message long-press menu). Each anchors on a token obfuscation can't touch —
+ * slide-out chat menu, message long-press menu). Each anchors on a token obfuscation cannot touch —
  * an enum-constant name (`CALENDAR` / `CALENDAR_BUTTON`) or a resource id.
  */
 
-// The Chats-tab header button enum (`az0.q`); the constant names survive obfuscation.
+// The Chats-tab header button enum (`az0.q`). The constant names survive obfuscation.
 private const val BUTTON_ENUM = "Laz0/q;"
 
 // The header button list is a `fb8/b`. Pinning the `add`'s definingClass separates it from the
@@ -35,7 +35,7 @@ internal object CalendarButtonFingerprint : Fingerprint(
 
 /**
  * The "+" attach-menu calendar tile is `hg1.b` (CalendarButtonType). Matches its constructor — the
- * only method that READS `fg1.a$b.CALENDAR`; the sole other reference is the enum's own `<clinit>`
+ * only method that READS `fg1.a$b.CALENDAR`. The sole other reference is the enum's own `<clinit>`
  * write, excluded by the constructor's parameter signature. `definingClass` (`Lhg1/b;`) then gives
  * the class whose availability predicate `j(...)` gets neutered.
  */
@@ -51,7 +51,7 @@ internal object AttachMenuCalendarButtonFingerprint : Fingerprint(
  * The chat-room top-toolbar calendar button is added inside `ed1.d0.a(...)` at two sites (one per
  * chat-type branch), each an `sget-object <ed1.g1.CALENDAR_BUTTON>` followed by the `ed1.s1.g(...)`
  * "add header button" call. Two `CALENDAR_BUTTON` filters pin this method — the only one reading the
- * constant twice — and yield both `sget-object` indices. (`ed1.u0$b` reads it once, so it can't
+ * constant twice — and yield both `sget-object` indices. (`ed1.u0$b` reads it once, so it cannot
  * satisfy two filters.)
  */
 internal object ChatRoomToolbarCalendarButtonFingerprint : Fingerprint(

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidecalendar/HideCalendarButtonPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidecalendar/HideCalendarButtonPatch.kt
@@ -23,7 +23,7 @@ val hideCalendarButtonPatch = bytecodePatch(
 
         // 2. Chat-room "+" attach menu: the CalendarButtonType (hg1.b) is shown only if its
         //    availability predicate `j(gi1.b)Z` returns true (the attach-menu filter hg1.r.f
-        //    gates on it). Neuter that predicate to false; the item is then dropped by the
+        //    gates on it). Neuter that predicate to false. The item is then dropped by the
         //    existing filter in gg1.e. Anchor via the constructor (the sole reader of the
         //    fg1.a$b.CALENDAR enum constant), then select `j` by its unique descriptor.
         val attachMenuCalendarClass =
@@ -42,7 +42,7 @@ val hideCalendarButtonPatch = bytecodePatch(
 
         // 3. Chat-room top toolbar: ed1.d0.a adds the button at two chat-type branches, each a
         //    `sget-object CALENDAR_BUTTON` + following `ed1.s1.g(...)` add call. Remove both
-        //    pairs. instructionMatches[0] = earlier site, [1] = later; remove the higher index
+        //    pairs. instructionMatches[0] = earlier site, [1] = later. Remove the higher index
         //    first so the earlier one stays valid.
         val toolbarMatches = ChatRoomToolbarCalendarButtonFingerprint.instructionMatches
         ChatRoomToolbarCalendarButtonFingerprint.method.apply {
@@ -51,7 +51,7 @@ val hideCalendarButtonPatch = bytecodePatch(
         }
 
         // 4. Slide-out chat menu: the calendar row (d00.o) forwards its first ctor bool as the
-        //    row's isVisible field (d00.a.e); the menu builder only renders rows whose e is true.
+        //    row's isVisible field (d00.a.e). The menu builder only renders rows whose e is true.
         //    Force that bool false at method entry (p1 is the first param) so the row is filtered
         //    out.
         ChatMenuCalendarRowFingerprint.method.addInstructions(0, "const/4 p1, 0x0")

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidegift/HideGiftButtonPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidegift/HideGiftButtonPatch.kt
@@ -13,7 +13,7 @@ val hideGiftButtonPatch = bytecodePatch(
     compatibleWith(COMPATIBILITY_LINE)
 
     // The LINE GIFT tile (hg1.h) is shown only if its availability predicate `j(gi1.b)Z` returns
-    // true (the attach-menu filter hg1.r.f gates on it). Neuter that predicate to false; the tile
+    // true (the attach-menu filter hg1.r.f gates on it). Neuter that predicate to false. The tile
     // is then dropped by the existing filter in gg1.e. Anchor via the constructor (the sole reader
     // of the fg1.a$b.GIFT enum constant), then select `j` by its unique descriptor.
     execute {

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidehomemodules/HideHomeModulesPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidehomemodules/HideHomeModulesPatch.kt
@@ -32,7 +32,7 @@ val hideHomeModulesPatch = bytecodePatch(
     // The filtering loop is a new method x72.h$a.filterHomeModules (backward-branching loops
     // corrupt an existing method's layout when injected inline -> VerifyError). We then inject
     // a branchless call at the top of x72.h$a.<init> to replace p1 (the list) with its
-    // filtered copy before it's stored. One constructor covers every feed build path + copies.
+    // filtered copy before it is stored. One constructor covers every feed build path + copies.
     //
     // "Hide Home content feed" prepends the same call shape at the same index. Both are pure
     // List -> List filters on p1. Thus the patch that applies second runs first, and the

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidepremium/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidepremium/Fingerprints.kt
@@ -7,7 +7,7 @@ import app.morphe.patcher.string
  * `b13.l.h()Z` — a sibling accessor in the LYP premium facade impl
  * (`com.linecorp.line.lyppremium.impl.LypPremiumFacadeImpl`, obfuscated `b13.l`). Anchored on the
  * globally-unique, non-obfuscated string `"LITE_ENJOY"` to locate the (fully obfuscated) facade
- * class. We do NOT patch `h()`; from the class we read `z()` to resolve the market-availability
+ * class. We do NOT patch `h()`. From the class we read `z()` to resolve the market-availability
  * config gate `e13.a.d()` and force it false. Obfuscated types (`b13.l`, `e13.a`, `t13.q`) drift
  * between versions, so we never hardcode them.
  */
@@ -25,9 +25,9 @@ internal object PremiumFacadeFingerprint : Fingerprint(
  *
  * That string is not globally unique — it also appears in the worker helper
  * `com.linecorp.line.premium.backup.impl.common.worker.a.a()V` — so the `(String, Z)Unit`
- * signature is pinned to disambiguate; the two enclosing methods share nothing else.
+ * signature is pinned to disambiguate. The two enclosing methods share nothing else.
  *
- * We do NOT patch `h()`; we only need its `definingClass` to reach the premium-backup
+ * We do NOT patch `h()`. We only need its `definingClass` to reach the premium-backup
  * availability gate `ic4.d.j()` (see the patch). `vc4.k0`, `vc4.a0` and `ic4.d` are all
  * obfuscated and drift between versions, so none of them is hardcoded.
  */

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidepremium/HidePremiumPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidepremium/HidePremiumPatch.kt
@@ -35,7 +35,7 @@ val hidePremiumPatch = bytecodePatch(
     //   status mapper j13.m      -> i$d Unavailable when !d() (o()/a(), 10 instanceof hides)
     // Forcing d() = false reproduces the shipped "LYP not available here" state — the app's own
     // default for non-premium markets. Premium-scoped: the shared jw4.i1.W() that non-premium
-    // features read is untouched, since we patch e13.a.d(), not i1.W().
+    // features read is untouched, because we patch e13.a.d(), not i1.W().
     //
     // The obfuscated facade b13.l is located via the unique string "LITE_ENJOY", then its z()
     // accessor resolves e13.a.d() with no drifting name hardcoded: z() is the only parameterless
@@ -74,7 +74,7 @@ val hidePremiumPatch = bytecodePatch(
         // premium chat-BACKUP flag (ic4.d.j(), a separate server config via vc4.a0 ->
         // m2.a().i0().g()) stays on. The Chats settings screen then renders the premium-backup row,
         // whose badge provider asks the facade for an icon and gets null from b13.l.E()
-        // (`if (!z()) return null`); the one view holder that doesn't null-guard calls
+        // (`if (!z()) return null`). The one view holder that does not null-guard calls
         // Context.getDrawable(0) -> Resources$NotFoundException, killing Settings > Chats. Flipping
         // the backup gate too makes both halves match a real non-LYP market.
         //
@@ -96,7 +96,7 @@ val hidePremiumPatch = bytecodePatch(
                 } == true
         }
 
-        // `.locals 0`, so p0 is the only register — and it's dead after the immediate return.
+        // `.locals 0`, so p0 is the only register — and it is dead after the immediate return.
         backupGate.addInstructions(
             0,
             """

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidepremiumunsend/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidepremiumunsend/Fingerprints.kt
@@ -13,7 +13,7 @@ import com.android.tools.smali.dexlib2.Opcode
  * false hides both, leaving the ordinary "Unsend / Close" dialog intact — its action buttons are
  * separate views.
  *
- * The literal `0x7f150bff` is globally unique; `opcode(INSTANCE_OF)` avoids pinning the drift-prone
+ * The literal `0x7f150bff` is globally unique. `opcode(INSTANCE_OF)` avoids pinning the drift-prone
  * inner-class name `…$a$c`.
  */
 internal object UnsendDiscreetlyButtonFingerprint : Fingerprint(
@@ -27,7 +27,7 @@ internal object UnsendDiscreetlyButtonFingerprint : Fingerprint(
  * Locates `wi1.j4` via the globally-unique "How to unsend discreetly" promo-link string id
  * (`0x7f150bf8`). Its constructor builds the promo link only when
  * `ne1.k2.a(i1.W() && i1.X(), …) == SUPPORTED_CHAT`, so forcing that first argument false leaves the
- * link handler null. The literal pins only the obfuscated class; the `k2.a` call site is then found
+ * link handler null. The literal pins only the obfuscated class. The `k2.a` call site is then found
  * by scanning it.
  */
 internal object UnsendPromoLinkFingerprint : Fingerprint(
@@ -44,7 +44,7 @@ internal object UnsendPromoLinkFingerprint : Fingerprint(
  * yourself more time" upsell in `oe1.c0.a`; past ~7 days the gate fails and no item is added.
  *
  * The premium-window read (`fieldAccess Lj51/a;->p`) is the instruction to rewrite; the readable enum
- * member `Lj51/c;->PREMIUM_UNSEND_MESSAGE` disambiguates the method, since only `y0$y.a` accesses
+ * member `Lj51/c;->PREMIUM_UNSEND_MESSAGE` disambiguates the method, because only `y0$y.a` accesses
  * both. Re-verify all three obfuscated descriptors (`Lj51/a;`, `Lj51/c;`, fields `p`/`o`) on a
  * version bump.
  */

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidepremiumunsend/HidePremiumUnsendPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidepremiumunsend/HidePremiumUnsendPatch.kt
@@ -29,11 +29,11 @@ val hidePremiumUnsendPatch = bytecodePatch(
         // `instance-of …$a$c` false so n3()/o3() take the hide branch, and (b) hide the green button
         // r3() itself. r3() exists ONLY in the silent dialog — NormalUnsendMessageLdsDialog.r3()
         // returns null and onViewCreated wires r3() under an `if (r3() != null)` guard — so hiding it
-        // can't affect the ordinary dialog, which keeps its Unsend/Close buttons (p3()/m3()).
+        // cannot affect the ordinary dialog, which keeps its Unsend/Close buttons (p3()/m3()).
         val dialogMethod = UnsendDiscreetlyButtonFingerprint.method
         val instructions = dialogMethod.implementation!!.instructions.toList()
 
-        // (b) first (higher index than the instance-of, so it doesn't shift that match's index):
+        // (b) first (higher index than the instance-of, so it does not shift that match's index):
         // r3() is the Button-returning no-arg call whose result is null-checked (invoke ->
         // move-result-object -> if-eqz). m3()/p3() are used without a null check. Hide it inside the
         // non-null branch. v0 is a safe scratch: the next original instruction overwrites it.
@@ -63,7 +63,7 @@ val hidePremiumUnsendPatch = bytecodePatch(
         // --- 2) "How to unsend discreetly" promo link (wi1.j4 constructor) ---
         // The link handler is created only when `k2.a(i1.W() && i1.X(), …) == SUPPORTED_CHAT`.
         // Force k2.a's first argument (the W()&&X() result) to 0 so it returns non-SUPPORTED and
-        // the link stays null. k2.a is called exactly once in this class; obfuscated `Lne1/k2;`
+        // the link stays null. k2.a is called exactly once in this class. Obfuscated `Lne1/k2;`
         // drifts between versions (re-verify on version bump).
         val promoClass = mutableClassDefBy(UnsendPromoLinkFingerprint.method.definingClass)
         var promoPatched = false

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hideshoppingtab/HideShoppingTabPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hideshoppingtab/HideShoppingTabPatch.kt
@@ -19,7 +19,7 @@ val hideShoppingTabPatch = bytecodePatch(
     // ever sees one of them. Dropping only the `add` leaves the branch's trailing `goto` in
     // place, so no other tab moves into the freed slot — matching stock LINE, which shows
     // nothing there when the commerce gate is on.
-    // instructionMatches[0] = COMMERCE (earlier), [1] = COMMERCE_TW (later); remove the higher
+    // instructionMatches[0] = COMMERCE (earlier), [1] = COMMERCE_TW (later). Remove the higher
     // index first so the earlier one stays valid.
     execute {
         val matches = ShoppingTabListFingerprint.instructionMatches

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidetransfer/HideTransferButtonPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidetransfer/HideTransferButtonPatch.kt
@@ -13,7 +13,7 @@ val hideTransferButtonPatch = bytecodePatch(
     compatibleWith(COMPATIBILITY_LINE)
 
     // The Transfer tile (hg1.k) is shown only if its availability predicate `j(gi1.b)Z` returns
-    // true (the attach-menu filter hg1.r.f gates on it). Neuter that predicate to false; the tile
+    // true (the attach-menu filter hg1.r.f gates on it). Neuter that predicate to false. The tile
     // is then dropped by the existing filter in gg1.e. Anchor via the constructor (the sole reader
     // of the fg1.a$b.PAY enum constant), then select `j` by its unique descriptor.
     execute {

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidewallettab/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidewallettab/Fingerprints.kt
@@ -10,7 +10,7 @@ private const val MAIN_TAB = "Ljp/naver/line/android/activity/main/a;"
  *
  * The main-tab enum `jp.naver.line.android.activity.main.a` is non-obfuscated, so its `MINI`
  * and `WALLET` constants are stable anchors. The builder appends `MINI` (mini-tab mode,
- * earlier) and `WALLET` (normal, later); both resolve to the Wallet/Pay fragment. Matching on
+ * earlier) and `WALLET` (normal, later). Both resolve to the Wallet/Pay fragment. Matching on
  * both field accesses (in program order) uniquely identifies this method and yields the two
  * `sget-object` indices to remove.
  */

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidewallettab/HideWalletTabPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidewallettab/HideWalletTabPatch.kt
@@ -15,7 +15,7 @@ val hideWalletTabPatch = bytecodePatch(
 
     // The tab-list builder appends MINI then WALLET, each as `sget-object <const>` followed by
     // `ArrayList.add`. Remove both pairs. instructionMatches[0] = MINI (earlier), [1] = WALLET
-    // (later); remove the higher index first so the earlier one stays valid.
+    // (later). Remove the higher index first so the earlier one stays valid.
     execute {
         val matches = WalletTabListFingerprint.instructionMatches
         val miniIndex = matches[0].index

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/keepunread/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/keepunread/Fingerprints.kt
@@ -10,7 +10,7 @@ import app.morphe.patcher.methodCall
  * locate the read-manager class `q33.e` (all of q33.e's names are obfuscated and have no
  * string literals).
  *
- * We don't patch this worker (it's shared by manual mark-as-read); we only use it to find the
+ * We do not patch this worker (it is shared by manual mark-as-read). We only use it to find the
  * class, then no-op the sibling open-on-view wrapper `b(String, String)` in the same class.
  */
 internal object ReadWorkerFingerprint : Fingerprint(

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/keepunsent/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/keepunsent/Fingerprints.kt
@@ -21,7 +21,7 @@ import app.morphe.patcher.string
  * The `Object invoke(Object)` signature additionally pins it to the Kotlin lambda itself.
  *
  * The strings are only used to *locate* the method — the guard is then found by instruction shape,
- * since `i38.c` and its `h()` are obfuscated and drift between LINE versions.
+ * because `i38.c` and its `h()` are obfuscated and drift between LINE versions.
  */
 internal object UnsendMessageDbWriteFingerprint : Fingerprint(
     returnType = "Ljava/lang/Object;",

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/keepunsent/KeepUnsentMessagesPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/keepunsent/KeepUnsentMessagesPatch.kt
@@ -82,7 +82,7 @@ val keepUnsentMessagesPatch = bytecodePatch(
         val rowRegister = (instructions[rowReadIndex] as TwoRegisterInstruction).registerB
 
         // The message id, read off that row between load and guard. Which of i38.b's longs it is
-        // (local vs server id) doesn't matter — the extension's WHERE clause accepts either. On
+        // (local vs server id) does not matter — the extension's WHERE clause accepts either. On
         // 26.11.0 it is `b`, the server id.
         val messageIdRegister = ((rowReadIndex + 1) until guardIndex)
             .firstOrNull { index ->
@@ -106,7 +106,7 @@ val keepUnsentMessagesPatch = bytecodePatch(
 
         // The transaction's SQLiteDatabase, read off the g38.f3 receiver inside the block we skip.
         // Reuse that exact field reference and holder register rather than hardcoding g38.f3.b.
-        // The field reference travels safely (it is position-independent); the register number only
+        // The field reference travels safely (it is position-independent). The register number only
         // does if the register provably holds the field's owner at the injection point, so require
         // a dominating cast. That also rejects the second SQLiteDatabase read further down this
         // method (h38.t0.a), which reuses the same register for a different type.
@@ -124,7 +124,7 @@ val keepUnsentMessagesPatch = bytecodePatch(
         val (databaseField, databaseHolderRegister) = databaseRead
             ?: throw PatchException("unsend: SQLiteDatabase field read not found in ${method.definingClass}")
 
-        // v0-v15 only for iget-object (22c) and invoke-static (35c); referencing v16+ there is
+        // v0-v15 only for iget-object (22c) and invoke-static (35c). Referencing v16+ there is
         // silently mis-assembled. On 26.11.0 these are v1/v6/v7, but the method is `.locals 29`,
         // so a future version could spill them. Fail loudly rather than keeping messages with no
         // notice: an unmarked kept message is indistinguishable from one that was never unsent.

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/removeads/RemoveBannerAdsPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/removeads/RemoveBannerAdsPatch.kt
@@ -14,7 +14,7 @@ val removeBannerAdsPatch = bytecodePatch(
     name = "Remove banner ads",
     description = "LINE no longer loads the Smart Channel banner ads. This patch makes the " +
         "getBanners and getPrefetchableBanners responses null.",
-    default = true, // applied by default in Morphe Manager; users can deselect it.
+    default = true, // applied by default in Morphe Manager. Users can deselect it.
 ) {
     compatibleWith(COMPATIBILITY_LINE)
 

--- a/patches/src/main/kotlin/app/andrewliang/patches/shared/Constants.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/shared/Constants.kt
@@ -8,9 +8,9 @@ object Constants {
     /**
      * LINE messenger (jp.naver.line.android).
      *
-     * LINE is distributed as a split app bundle, hence [ApkFileType.APKM].
-     * Pin the exact version the patches were developed and confirmed against;
-     * add to this list as new versions are verified.
+     * LINE ships as a split app bundle, so it uses [ApkFileType.APKM].
+     * Pin the exact version the patches were developed and confirmed against.
+     * Add a new version to this list after you verify it.
      */
     val COMPATIBILITY_LINE = Compatibility(
         name = "LINE",

--- a/patches/src/main/kotlin/util/PatchListGenerator.kt
+++ b/patches/src/main/kotlin/util/PatchListGenerator.kt
@@ -47,14 +47,14 @@ private fun generatePatchList(version: String, patches: Set<Patch<*>>) {
             default = patch.default,
             dependencies = patch.dependencies.map { it.javaClass.simpleName },
             // Map each Compatibility to a JsonCompatibility object with full metadata.
-            // Patches with null compatiblePackages are universal (apply to any app).
+            // A patch with null compatiblePackages is universal and applies to any app.
             compatiblePackages = patch.compatibility?.map { compat ->
                 JsonCompatibility(
                     packageName = compat.packageName!!,
                     name = compat.name,
                     description = compat.description,
                     apkFileType = compat.apkFileType?.name,
-                    // Format as #RRGGBB string for readability; null if not set
+                    // Format as a #RRGGBB string for readability. Null if it is not set.
                     appIconColor = compat.appIconColor?.let { "#%06X".format(it) },
                     signatures = compat.signatures,
                     targets = compat.targets.map { target ->


### PR DESCRIPTION
Applies a pragmatic ASD-STE100 (Simplified Technical English) pass across the docs and code comments. Wording and structure only — no fingerprint descriptor, smali snippet, string literal, resource id, or technical claim changed.

## What changed
- **Semicolons (rule 8.1):** ~50 prose `clause; clause` joins split into two sentences, in source comments and the reference maps. Left semicolons inside reference-table cells and inline enumerations (compact fact separators) and inside smali descriptors like `Lfb8/b;`.
- **Contractions:** expanded (`can't → cannot`, `don't → do not`, …) everywhere.
- **Latinisms / abbreviations:** `e.g. → for example`, `i.e. → that is`, `etc. → and more`; `hence/therefore → thus/so`; causal `since → because`.
- **Passive + long sentences:** rewrote the worst offenders in the hand-edited comments (`chatheaderbuttons`, `fixpushnotifications`, `externalbrowser`, `Constants`, `PatchListGenerator`) into active, one-idea sentences.

## Verified
- `:patches:compileKotlin` builds clean offline.
- All four extension Java files have balanced Javadoc delimiters.

## Deliberately untouched
- Generated files: `patches-list.json`, `patches-bundle.json`, `CHANGELOG.md`, `gradle.properties`, README `PATCHES` block.
- `CLAUDE.md` — operational instruction file where directive nuance matters; excluded on purpose.
- Patch `description` strings and README prose — already Simple-English from prior passes, no remaining violations.
- The two Whoscall investigation notes — kept untracked as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)