### PR TITLE
fix: resolve every hidepremium lookup before the first mutation

### DIFF
--- a/docs/line-patch-map.md
+++ b/docs/line-patch-map.md
@@ -201,7 +201,8 @@ screenshot. That is the only step separating "the instructions are gone" from "t
 
 The Home tab renders a single server-driven `List<m52.z>`. Everything on the tab is one of these
 modules — the friends list, the service icons, the ads, and the whole content feed below the friends
-list. Two patches filter that list.
+list. Three patches filter that list: *Hide Home modules*, *Hide Home content feed*, and
+*Disable LINE Premium*. If you change this surface, update all three call sites.
 
 **The chain.** `v52.g.a(Ls52/i;Lm52/m0;)` assembles the list from the GCS response (one giant
 `packed-switch` over the payload oneof; **jadx fails on this method** — `Method not decompiled` — so
@@ -216,11 +217,11 @@ way:
 
 - **The loop must live in a new method.** A backward-branching loop injected into an existing method
   corrupts the branch layout into a runtime `VerifyError`. Add
-  `x72.h$a.filterHomeModules` / `filterHomeFeed` with `mutableClassDefBy(...).methods.add(...)` and
-  inject only the call.
-- **Both patches prepend at index 0, and that is safe.** Each is a pure `List → List` filter on `p1`,
-  so whichever patch applies second simply runs first — verified in the dex: the ctor starts with the
-  two `invoke-static` + `move-result-object v1` pairs chained, then the original
+  `x72.h$a.filterHomeModules` / `filterHomeFeed` / `filterPremiumModules` with
+  `mutableClassDefBy(...).methods.add(...)` and inject only the call.
+- **All three patches prepend at index 0, and that is safe.** Each one is a pure `List → List`
+  filter on `p1`. Thus the patch that applies last runs first. The dex confirms it: the ctor starts
+  with the `invoke-static` + `move-result-object v1` pairs chained, then the original
   `Object.<init>` + `iput-object v1 → field a`.
 - The earlier target `i52.c.e` built only the Friends sub-tab list (a single
   `FriendsSubTabFriendsList`), not the feed — confirmed via on-device logging.
@@ -249,7 +250,7 @@ in `m52/a0.java`; **two are top-level and easy to miss** (`m52.c0`, `m52.d0`).
 | `CommerceTwTabFriendshipGifts`, `-GreetingBanners`, `-QuickPolls`, `-Shortcuts` | `a0$b`–`a0$e` | the TW commerce tab | kept |
 | `HomeActivityCard` | `a0$q` | recommendation surface (`contentList` / `extraContentList`) | **not blocked** — no device evidence |
 | `GcsHomeActivityHybridContentCard` | `m52.d0` (top-level) | the hybrid variant of the above | **not blocked** — no device evidence |
-| `HomeTabLypRecommendation` | `a0$n0` | LYP premium upsell | **not blocked** — belongs to *Disable LINE Premium*, see `line-premium-map.md` |
+| `HomeTabLypRecommendation` | `a0$n0` | LYP premium upsell | **Disable LINE Premium** (third lever, no device evidence — see `line-premium-map.md`) |
 | `GcsDummyHybridModule` | `m52.c0` (top-level) | dev/dummy, no renderer | kept |
 
 **Take this table from jadx, never from a smali grep.** 17 of the 43 nested classes are Kotlin

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidepremium/HidePremiumPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidepremium/HidePremiumPatch.kt
@@ -41,6 +41,13 @@ val hidePremiumPatch = bytecodePatch(
     // accessor resolves e13.a.d() with no drifting name hardcoded: z() is the only parameterless
     // ()Z facade method with exactly two invoke-virtuals (`return H().d()`), and its 2nd call is
     // <config>.d() — the class + method to neuter.
+    //
+    // This patch has three levers. It resolves every fingerprint and every lookup BEFORE the first
+    // addInstructions, because the patcher does not undo a partial execute. If a later lookup
+    // throws, the Manager reports the patch as failed but the earlier lever still ships. The user
+    // then gets a half-disabled premium. Nothing in the Manager shows this state, and nothing
+    // undoes it. The Compose-state ctor of the third lever is the most drift-prone lookup, so it
+    // must resolve before the first mutation.
     execute {
         val facade = mutableClassDefBy(PremiumFacadeFingerprint.method.definingClass)
 
@@ -61,14 +68,6 @@ val hidePremiumPatch = bytecodePatch(
                 method.returnType == "Z" &&
                 method.parameterTypes.isEmpty()
         }
-
-        marketGate.addInstructions(
-            0,
-            """
-                const/4 v0, 0x0
-                return v0
-            """,
-        )
 
         // Flipping d() alone leaves a state LINE never ships: premium "unavailable" while the
         // premium chat-BACKUP flag (ic4.d.j(), a separate server config via vc4.a0 ->
@@ -96,15 +95,6 @@ val hidePremiumPatch = bytecodePatch(
                 } == true
         }
 
-        // `.locals 0`, so p0 is the only register — and it is dead after the immediate return.
-        backupGate.addInstructions(
-            0,
-            """
-                const/4 p0, 0x0
-                return p0
-            """,
-        )
-
         // Third lever: the Home tab upsell module. The Home tab shows one server-driven list of
         // typed modules. The LYP recommendation is the module of type "HomeTabLypRecommendation"
         // (m52.a0$n0, payload m52.y). The master lever does not hide it. Its renderer ac2.k and
@@ -116,14 +106,33 @@ val hidePremiumPatch = bytecodePatch(
         // path goes to that constructor. One literal comparison needs no extension code, so this
         // patch declares no extension.
         //
-        // The loop lives in a new method, x72.h$a.filterPremiumModules. If a patch injects a loop
-        // with a backward branch inline, the loop corrupts the layout of an existing method. ART
-        // then throws a VerifyError.
-        //
         // "Hide Home modules" and "Hide Home content feed" prepend the same call shape at the
         // same index. All three are pure List -> List filters on p1. Thus the patch that applies
         // last runs first, and the result is the same in every order.
         val homeState = mutableClassDefBy(HOME_STATE)
+        val homeStateCtor = HomeStateCtorFingerprint.method
+
+        // Every lookup is resolved. The patch mutates from this point.
+        marketGate.addInstructions(
+            0,
+            """
+                const/4 v0, 0x0
+                return v0
+            """,
+        )
+
+        // `.locals 0`, so p0 is the only register — and it is dead after the immediate return.
+        backupGate.addInstructions(
+            0,
+            """
+                const/4 p0, 0x0
+                return p0
+            """,
+        )
+
+        // The loop lives in a new method, x72.h$a.filterPremiumModules. If a patch injects a loop
+        // with a backward branch inline, the loop corrupts the layout of an existing method. ART
+        // then throws a VerifyError.
         val filter = MutableMethod(
             ImmutableMethod(
                 HOME_STATE,
@@ -170,7 +179,7 @@ val hidePremiumPatch = bytecodePatch(
         // At the top of x72.h$a.<init>, replace the list parameter (p1) with the filtered copy
         // before the constructor stores it. The call has no branch (invoke + move-result) and it
         // reuses p1 (`.locals 0`).
-        HomeStateCtorFingerprint.method.addInstructions(
+        homeStateCtor.addInstructions(
             0,
             """
                 invoke-static {p1}, $HOME_STATE->$FILTER_NAME$FILTER_DESC


### PR DESCRIPTION
Follow-up to the code review of #73.

## The problem

`Disable LINE Premium` resolved `HomeStateCtorFingerprint` at the end of `execute`. Two mutations ran before it: `marketGate.addInstructions` and `backupGate.addInstructions`. The patcher does not undo a partial `execute`.

The 11-parameter Compose-state constructor is the most drift-prone lookup in this patch. If its signature changes in a later LINE build, three things happen:

- The Manager reports `Disable LINE Premium` as failed.
- Both gate flips still ship in the output APK.
- An orphan `filterPremiumModules` stays on `x72.h$a`.

The user then gets a half-disabled premium. Nothing in the Manager shows this state, and nothing undoes it.

`PremiumBackupFacadeFingerprint` had the same problem. It resolved after the market gate flip.

## The fix

`execute` has two phases: a resolve phase, then a mutate phase. Every fingerprint, every `mutableClassDefBy` and every `.single { }` selection runs before the first `addInstructions`. Thus the patch fails before it changes anything. Each explanatory comment stays with the lookup that it describes.

When the patch applies without errors, it produces the same bytecode as before. The three injections, the registers and the order-independent `List → List` filters do not change.

## Docs

The Home tab section of `docs/line-patch-map.md` is the version-bump checklist for this surface. Three claims in it went stale when the third lever landed in d4362b3:

- "Two patches filter that list" becomes three: `hidehomemodules`, `hidehomefeed` and `hidepremium`.
- "Both patches prepend at index 0" becomes all three patches.
- The module inventory marked `HomeTabLypRecommendation` as not blocked, but `Disable LINE Premium` blocks it.

`docs/line-premium-map.md` already said three, so the two maps contradicted each other.

## Verification

`./gradlew :patches:buildAndroid --offline` compiles without errors. This change is ordering only, and it adds no new fingerprint and no new smali. Thus I did not apply the bundle to an APK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)