### PR TITLE
fix: stop the Home tab refetch loop that "Hide Home content feed" starts

### DIFF
--- a/docs/line-patch-map.md
+++ b/docs/line-patch-map.md
@@ -265,9 +265,71 @@ variants, so a literal list reopens the hole on the next rotation. The extension
 `type.startsWith("HomeFeed")` instead. The error and loading placeholders are included on purpose, so
 no orphan spinner or error shell is left where the cards were.
 
+That covers the *module* spinners. It does not cover the page footer spinner, because that spinner
+is not a module. The section that follows covers it.
+
 **No `function.*` config gate exists for this feed.** `function.hometab.*`, `function.line_home.*` and
 `function.my_home.*` carry no feed switch, so filtering the module list is the only cheap mechanism —
 this is not a "force the gate false" surface.
+
+### Filtering a paged list starts a refetch loop — the second and third levers
+
+**The general lesson, before the detail: LINE measures the page *after* our filter runs.** When you
+remove items from a paged surface, the change thus feeds back into the pager. Every future
+list-filtering patch must check whether the surface pages. A patch that does not check ships a
+silent refetch loop. `hidehomefeed` needed two levers more than the filter. The reporter of issue
+ #69 found the first one on `v1.8.0-dev.2`.
+
+**`x72.h$a` is `PageData`.** The ctor is
+`(List, Z, Z, Z, Z, Z, String, Long, Long, I, Z)` and holds, in order: `modules`, `isPageReady`,
+`isPageRefreshing`, `isError`, `isPullToRefreshLoading`, **`isLoadingMore`**, `orderRequestId`,
+`expiredTimeMillis`, `pageUpdatedTimeMillis`, `revision`, `isSafeMode`. The `toString()` of the
+class names every field, thus it gives the order. Cross-check that order against the four consumers
+(`v72/q.java`, `v72/r.java`, `v72/s.java`, `v72/t.java`). **Re-check this order on a version bump.**
+The patch writes ctor parameter 6 by position.
+
+**LINE has no empty state.** `GcsModuleListViewDataFacade.viewDataFlow` (`v72/u.java`) reduces
+`PageData` to `v72.n`:
+
+```java
+if (any x in list has f333354g != 0) return new n.a(revision, list, delayedIsLoadingMore); // Content
+if (isError) return n.b;                                                                   // Error
+return delayedIsPageRefreshing ? n.d : n.c;                                                // Loading : Idle
+```
+
+`x.f333354g` counts the sub-items of the module. "Shows nothing" and "still loads" are thus the
+same state to LINE. The renderer `v72/x0.java` makes lazy-list items from that state. `n.d` becomes
+a whole-page spinner (line 142). Inside `n.a`, an `isLoadingMoreContent` adds the `q2.LOADING_MORE`
+footer (line 291).
+
+**The pager trigger** is `v72/m1.java:81` — `lastVisibleIndex + 6 >= itemCount`, gated on
+`isPageReady`. A tab with no feed is short, thus this condition stays true always. One place reads
+the trigger: `v72/o1.java:38`
+(`GcsPageState$observeEventsForLoadingModuleContent$1`), which calls `d2.B1(shouldLoadMore)`.
+
+**The fetch** is `v72.h2.B1(Z)V` (`v72/h2.java:44`), the one implementation of `B1` that does work.
+`v72/o1.java:38` is its only caller in the app. Each fetch returns feed modules, and the filter
+discards them. The item count does not grow, thus the next fetch starts. The server sends an endless
+feed, so the `i0Var.f229286b` ("no more pages") guard is never true.
+
+| Lever | Site | Injection |
+|---|---|---|
+| 1. filter the list | `x72.h$a.<init>` index 0 | `invoke-static filterHomeFeed` + `move-result-object p1` |
+| 2. hide the footer | same block | `const/4 p6, 0x0` (p6 = `isLoadingMore`, `.locals 0`, 12 registers, so v6) |
+| 3. stop the pager | `v72.h2.B1(Z)V` index 0 | `return-void` |
+
+**Lever 3 is safe because LINE ships an empty `B1` of its own.** `b82/z.java` implements `v72.d2`
+with every method empty, `B1` included. An empty `B1` is thus a state that LINE itself builds. Only
+load-more goes through `B1`. The initial load, the pull-to-refresh and the visibility are separate
+interface methods (`P4`, `R2`, `Q1`, `L`, `r5`, `w6`, `n4`).
+
+**Anchor lever 3 on shape, never on the drift-prone name `B1`.** Use `returnType = "V"`,
+`parameters = ["Z"]`, plus `fieldAccess(type = "Lx72/h;")` and `checkCast("Lm52/i0;")`. On LINE
+26.11.0 that combination matches one method in the whole APK. A sweep of every `.smali` confirms it.
+
+Lever 3 prevents the spinner on its own, but lever 2 stays. Lever 2 costs one instruction on a
+fingerprint that the patch already owns. Field `f` has one reader, thus lever 2 cannot break
+anything else.
 
 ### The feed is region-driven — plan for a remote tester
 

--- a/extensions/extension/src/main/java/app/andrewliang/extension/HomeFeed.java
+++ b/extensions/extension/src/main/java/app/andrewliang/extension/HomeFeed.java
@@ -23,8 +23,13 @@ package app.andrewliang.extension;
  * This helper tests the prefix and not the 14 literal strings. The server rotates between card
  * variants, and it sends different variants to different regions. A Taiwan account gets none
  * of these modules, but a Japanese account gets them. Thus a literal list does not cover the
- * next rotation. The prefix also matches the error and loading types, so no empty spinner or
- * error card stays on the tab.
+ * next rotation. The prefix also matches the error and loading module types, so no empty error
+ * card and no module spinner stays on the tab.
+ *
+ * The prefix does not cover the page footer spinner, because that spinner is not a module. The
+ * Home tab is a paged surface, and LINE measures the page after this filter runs. A tab with no
+ * feed is short. LINE thus asks for page after page, and this filter discards each one. The
+ * patch needs two levers more for that loop. See HideHomeFeedPatch.
  *
  * The Home modules above the feed are a different patch. See HomeModules for the recommended
  * stickers, the hot topics and the ads.

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidehomefeed/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidehomefeed/Fingerprints.kt
@@ -1,6 +1,8 @@
 package app.andrewliang.patches.line.hidehomefeed
 
 import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.checkCast
+import app.morphe.patcher.fieldAccess
 
 /**
  * `x72.h$a.<init>(List<m52.z>, ...)` — the constructor of the Home Compose UI state. The state
@@ -25,5 +27,32 @@ internal object HomeStateCtorFingerprint : Fingerprint(
         "Ljava/lang/Long;",
         "I",
         "Z",
+    ),
+)
+
+/**
+ * `v72.h2.B1(Z)V` — the "load more module content" action of the GCS page view model
+ * (`com.linecorp.line.gcs.page.ui`, obfuscated `v72.h2`, which implements the page action
+ * interface `v72.d2`). The method asks the page repository `x72.h` for the next feed page.
+ *
+ * The patch makes this method return at once. The filter makes the Home tab short, thus LINE's
+ * pager trigger (`lastVisibleIndex + 6 >= itemCount`) stays true. The app then asks for page
+ * after page, and the filter discards each one. See HideHomeFeedPatch.
+ *
+ * The whole app calls `d2.B1` from one place: the pager observer
+ * `GcsPageState$observeEventsForLoadingModuleContent$1`. LINE also ships an empty `d2` of its
+ * own (`b82.z`, every method empty), thus an empty `B1` is a state that LINE builds itself.
+ *
+ * Anchored on shape, and not on the drift-prone name `B1`: the `(Z)V` signature, the read of
+ * the `x72.h` repository field, and the cast of the page info to `m52.i0`. On LINE 26.11.0
+ * that combination matches one method in the APK. This object never names the obfuscated
+ * types `v72.h2`, `v72.d2` or `x72.r`.
+ */
+internal object LoadMoreContentFingerprint : Fingerprint(
+    returnType = "V",
+    parameters = listOf("Z"),
+    filters = listOf(
+        fieldAccess(type = "Lx72/h;"),
+        checkCast("Lm52/i0;"),
     ),
 )

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidehomefeed/HideHomeFeedPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidehomefeed/HideHomeFeedPatch.kt
@@ -40,7 +40,29 @@ val hideHomeFeedPatch = bytecodePatch(
     // "Hide Home modules" prepends the same call shape at the same index. Both are pure
     // List -> List filters on p1. Thus the patch that applies second runs first, and the
     // result is the same either way.
+    //
+    // The filter alone leaves the tab in a state that LINE does not expect. The Home tab is a
+    // paged surface, and LINE measures the page AFTER this filter runs. The pager trigger is
+    // `lastVisibleIndex + 6 >= itemCount` (GcsPageState). A tab with no feed is short, thus
+    // the trigger stays true. LINE then asks for page after page, and the filter discards each
+    // one. The item count never grows, and the loading footer stays. The reporter of issue #69
+    // saw that spinner on v1.8.0-dev.2.
+    //
+    // Two more levers correct this:
+    //   1. Stop the fetch. v72.h2.B1(Z) is the "load more module content" action, and one
+    //      place in the app calls it. An immediate return ends the loop.
+    //   2. Hide the footer. x72.h$a ctor parameter 6 is isLoadingMore, and its one reader is
+    //      the LOADING_MORE footer item. Lever 1 keeps it false on its own. This lever costs
+    //      one instruction on a fingerprint that the patch already owns. If lever 1 ever stops
+    //      matching, this lever still hides the spinner.
+    //
+    // Every fingerprint resolves before the first addInstructions, because the patcher does
+    // not undo a partial execute. If a lookup fails late, the Manager reports the patch as
+    // failed and the earlier lever still ships.
     execute {
+        val homeStateCtor = HomeStateCtorFingerprint.method
+        val loadMoreContent = LoadMoreContentFingerprint.method
+
         // 1. Add the static filter helper method to x72.h$a.
         val cls = mutableClassDefBy(HOME_STATE)
         val filter = MutableMethod(
@@ -87,12 +109,27 @@ val hideHomeFeedPatch = bytecodePatch(
         // 2. At the top of x72.h$a.<init>, replace the list parameter (p1) with the filtered
         //    copy before the constructor stores it. The call has no branch (invoke +
         //    move-result) and it reuses p1 (`.locals 0`).
-        HomeStateCtorFingerprint.method.addInstructions(
+        //
+        //    The same block clears parameter 6. The constructor is
+        //    <init>(List, Z, Z, Z, Z, Z, String, Long, Long, I, Z) and it holds
+        //    PageData(modules, isPageReady, isPageRefreshing, isError, isPullToRefreshLoading,
+        //    isLoadingMore, orderRequestId, expiredTimeMillis, pageUpdatedTimeMillis, revision,
+        //    isSafeMode). Parameter 6 is thus isLoadingMore, which the smali confirms:
+        //    `iput-boolean p6, p0, Lx72/h$a;->f:Z`. Field `f` has one reader in the app, the
+        //    map that feeds the LOADING_MORE footer item, so a false value hides that spinner
+        //    and changes nothing else. `.locals 0` and 12 registers put p6 at v6, which
+        //    const/4 accepts.
+        homeStateCtor.addInstructions(
             0,
             """
                 invoke-static {p1}, $HOME_STATE->$FILTER_NAME$FILTER_DESC
                 move-result-object p1
+                const/4 p6, 0x0
             """,
         )
+
+        // 3. Stop the pager. The immediate return stops the requests for feed pages that
+        //    step 1 then discards. The instructions that follow become unreachable.
+        loadMoreContent.addInstructions(0, "return-void")
     }
 }


### PR DESCRIPTION
Follow-up to #69. The reporter confirmed on `v1.8.0-dev.2` that the feed is gone. But a small spinner stays below the friends list.

## The problem

The spinner is not only cosmetic. It is the visible edge of a refetch loop that the patch itself starts.

**The Home tab is a paged surface, and LINE measures the page AFTER the filter runs.** The pager trigger is `lastVisibleIndex + 6 >= itemCount` (`v72/m1.java:81`), gated on `isPageReady`. A tab with no feed is short, thus the trigger stays true always. One place reads the trigger: `v72/o1.java:38`, which calls `d2.B1(shouldLoadMore)` and gets to the fetch at `v72/h2.java:44`. Each fetch returns feed modules, and the filter discards them. The item count does not grow, so the next fetch starts. The server sends an endless feed, thus the `i0Var.f229286b` ("no more pages") guard is never true.

The spinner itself comes from `GcsModuleListViewDataFacade` (`v72/u.java`), which has **no empty state**:

```java
if (any x in list has f333354g != 0) return new n.a(revision, list, delayedIsLoadingMore); // Content
if (isError) return n.b;                                                                   // Error
return delayedIsPageRefreshing ? n.d : n.c;                                                // Loading : Idle
```

An `isLoadingMoreContent` then adds the `q2.LOADING_MORE` footer item at `v72/x0.java:291`.

## The fix

Two levers, both in the patch that makes the condition. `hidehomemodules` removes a bounded set of modules and leaves the pager intact, thus it needs no change.

**Lever 1 stops the fetch:** `return-void` at index 0 of `v72.h2.B1(Z)V`.

LINE already ships an empty `v72.d2` of its own. `b82/z.java` implements the same interface with every method empty, `B1` included. An empty `B1` is thus a state that LINE itself builds, and not one that this patch invents. Only load-more goes through `B1`. The initial load, the pull-to-refresh and the visibility are separate interface methods (`P4`, `R2`, `Q1`, `L`, `r5`, `w6`, `n4`), and this patch does not touch them.

Lever 1 is anchored on shape, and not on the drift-prone name `B1`: the `(Z)V` signature, the read of the `x72.h` repository field, and the cast of the page info to `m52.i0`. A sweep of every `.smali` in the APK shows that this combination matches **one method**.

**Lever 2 hides the footer:** `const/4 p6, 0x0`, added to the injection that the patch already makes at index 0 of `x72.h$a.<init>`.

Parameter 6 is `isLoadingMore`. The dex proves this two ways. The constructor writes `iput-boolean p6, p0, Lx72/h$a;->f:Z`. The `toString()` of the class emits `", isLoadingMore="` immediately before field `f`. Field `f` has one reader in the app: the map that feeds the footer item. The method is `.locals 0` with 12 registers, thus p6 is v6, which `const/4` accepts.

Lever 1 keeps the spinner away on its own. Lever 2 stays because it costs one instruction on a fingerprint that the patch already owns, and it cannot break anything else. If lever 1 ever stops matching, the spinner stays hidden.

Every fingerprint resolves before the first `addInstructions`, per #75. A late failure must not ship one lever and report the patch as failed.

## Verification

Applied to LINE 26.11.0, alone and under the full default bundle:

- `v72.h2.B1` opens with `return-void`. The siblings `L()`, `P4()` and `Q1()` do not change.
- The constructor chains all three `List` filters (`filterHomeModules`, `filterHomeFeed`, `filterPremiumModules`) and puts `const/4 v6, #0` before its `iput-boolean v6 -> f`.
- The whole-dex branch-offset sweep is clean: 637352 methods, 1303392 branches, 72929 try blocks, **0 problems**.

**The device proof is still open.** The feed does not render on a Taiwan account, thus this fix needs the JP reporter on the pre-release that this PR cuts. Hold the `dev` to `main` merge (#73) until that screenshot arrives.

## Docs

`docs/line-patch-map.md` gets a section on the paged-surface trap. It gives the `PageData` field map, the `v72.u` reduction, the trigger, the fetch, and the anchors. The general lesson comes first: **a filter on a server-driven list can start a refetch loop, thus check whether the surface pages.** `HomeFeed.java` said that the prefix leaves "no empty spinner". That text is corrected: the prefix covers the module spinners, and not the page footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
