### PR TITLE
fix: hide the Friends sub-tab Calendar block

### DIFF
--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidecalendar/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidecalendar/Fingerprints.kt
@@ -91,3 +91,33 @@ internal object ContextMenuCalendarProviderFingerprint : Fingerprint(
         fieldAccess(definingClass = "Lc81/c;", name = "CALENDAR"),
     ),
 )
+
+/**
+ * `lb2.g$a.<init>(List<y82.j0>, ...)` — the constructor of the Home Compose UI state. Every GCS
+ * page state, including the Home tab's **Friends sub-tab**, funnels its rendered module list
+ * through this one constructor as the first argument (field `a`), so filtering the list here also
+ * covers the Friends sub-tab.
+ *
+ * The Friends sub-tab shows LINE Calendar as its own block, module type `FriendsSubTabCalendar`
+ * (`y82.k0$h`). That block is a 6th Calendar surface, and none of the five instruction-level
+ * levers above touch it: it is server-driven list data, not a statically-built button.
+ *
+ * This is a fourth copy of the same fingerprint, after `hidehomemodules`, `hidehomefeed` and
+ * `hidepremium`. Each patch keeps its own copy, because the four patches are independent and the
+ * user can apply any one alone. All four prepend a `List -> List` filter call at index 0 of this
+ * constructor, and each filter only drops its own module types, so the order does not matter.
+ */
+internal object HomeStateCtorFingerprint : Fingerprint(
+    definingClass = "Llb2/g\$a;",
+    name = "<init>",
+    returnType = "V",
+    parameters = listOf(
+        "Ljava/util/List;",
+        "Z", "Z", "Z", "Z", "Z",
+        "Ljava/lang/String;",
+        "Ljava/lang/Long;",
+        "Ljava/lang/Long;",
+        "I",
+        "Z",
+    ),
+)

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidecalendar/HideCalendarButtonPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidecalendar/HideCalendarButtonPatch.kt
@@ -4,18 +4,35 @@ import app.andrewliang.patches.shared.Constants.COMPATIBILITY_LINE
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.removeInstructions
 import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.builder.MutableMethodImplementation
+import com.android.tools.smali.dexlib2.immutable.ImmutableMethod
+import com.android.tools.smali.dexlib2.immutable.ImmutableMethodParameter
+
+private const val HOME_STATE = "Llb2/g\$a;"
+private const val FILTER_NAME = "filterCalendarModules"
+private const val FILTER_DESC = "(Ljava/util/List;)Ljava/util/List;"
+private const val CALENDAR_MODULE_TYPE = "FriendsSubTabCalendar"
 
 @Suppress("unused")
 val hideCalendarButtonPatch = bytecodePatch(
     name = "Hide calendar buttons",
-    description = "Removes every LINE Calendar button inside the messenger. One is in the " +
-        "Chats-tab header. The other four are in a chat room: the top toolbar, the + attach " +
-        "menu, the slide-out chat menu, and the message long-press menu.",
+    description = "Removes every LINE Calendar surface inside the messenger. One is in the " +
+        "Chats-tab header. Four are in a chat room: the top toolbar, the + attach menu, the " +
+        "slide-out chat menu, and the message long-press menu. The last is the Calendar block " +
+        "in the Friends sub-tab of the Home tab.",
     default = true,
 ) {
     compatibleWith(COMPATIBILITY_LINE)
 
     execute {
+        // Resolve the Home-state constructor before any mutation. The patcher does not undo a
+        // partial execute, so a lookup that throws after an earlier lever has already been
+        // written would ship a half-applied patch that nothing reports and nothing reverses.
+        val homeState = mutableClassDefBy(HOME_STATE)
+        val homeStateCtor = HomeStateCtorFingerprint.method
+
         // 1. Chats-tab header: remove the `sget-object CALENDAR` + following list `add(...)` pair
         //    so the header button is never added. instructionMatches[0] = the CALENDAR sget.
         val calendarSgetIndex = CalendarButtonFingerprint.instructionMatches.first().index
@@ -63,6 +80,65 @@ val hideCalendarButtonPatch = bytecodePatch(
             """
                 const/4 v0, 0x0
                 return-object v0
+            """,
+        )
+
+        // 6. Friends sub-tab: the Calendar block is a server-driven module of type
+        //    "FriendsSubTabCalendar", not a statically-built button, so none of the five levers
+        //    above reaches it. Drop it from the module list the Compose state renders.
+        //
+        //    The loop lives in a new method. Injecting a backward-branching loop inline corrupts
+        //    an existing method's branch layout, and ART then throws a VerifyError.
+        val filter = MutableMethod(
+            ImmutableMethod(
+                HOME_STATE,
+                FILTER_NAME,
+                listOf(ImmutableMethodParameter("Ljava/util/List;", null, null)),
+                "Ljava/util/List;",
+                AccessFlags.PUBLIC.value or AccessFlags.STATIC.value,
+                null,
+                null,
+                MutableMethodImplementation(6),
+            ),
+        )
+        homeState.methods.add(filter)
+        // p0 = input List. v0 = result ArrayList, v1 = iterator, v2 = element, v3 = type/bool,
+        // v4 = the literal. The literal is the receiver of equals(), so a null type is safe.
+        filter.addInstructions(
+            0,
+            """
+                new-instance v0, Ljava/util/ArrayList;
+                invoke-direct {v0}, Ljava/util/ArrayList;-><init>()V
+                invoke-interface {p0}, Ljava/util/List;->iterator()Ljava/util/Iterator;
+                move-result-object v1
+                :loop
+                invoke-interface {v1}, Ljava/util/Iterator;->hasNext()Z
+                move-result v2
+                if-eqz v2, :done
+                invoke-interface {v1}, Ljava/util/Iterator;->next()Ljava/lang/Object;
+                move-result-object v2
+                check-cast v2, Ly82/j0;
+                iget-object v3, v2, Ly82/j0;->e:Ly82/k0;
+                invoke-interface {v3}, Ly82/k0;->getType()Ljava/lang/String;
+                move-result-object v3
+                const-string v4, "$CALENDAR_MODULE_TYPE"
+                invoke-virtual {v4, v3}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
+                move-result v3
+                if-nez v3, :loop
+                invoke-virtual {v0, v2}, Ljava/util/ArrayList;->add(Ljava/lang/Object;)Z
+                goto :loop
+                :done
+                return-object v0
+            """,
+        )
+
+        //    Replace the list parameter (p1) with the filtered copy at the top of the ctor, before
+        //    it is stored. The call is branchless (invoke + move-result) and reuses p1.
+        homeStateCtor.addInstructions(
+            0,
+            """
+                invoke-static {p1}, $HOME_STATE->$FILTER_NAME$FILTER_DESC
+                move-result-object p1
             """,
         )
     }


### PR DESCRIPTION
## What this does

The patch "Hide calendar buttons" removed only five of the six LINE Calendar surfaces in the messenger. The Friends sub-tab of the Home tab shows Calendar as its own block. That block stayed on the device.

## Why the five levers missed it

The block is a server-driven module with the type `FriendsSubTabCalendar` (`y82.k0$h`). The code does not build it as a button, so no instruction-level lever reaches it.

This PR removes the block from the module list instead. It filters that list at the shared Compose state constructor `lb2.g$a.<init>`. Three patches already use this lever: hidehomemodules, hidehomefeed and hidepremium. Every GCS page state goes through that constructor, and this includes the Friends sub-tab.

## The gap is not new

The type is in 26.11.0 as `m52.a0$h`. The version bump did not break this block. The patch never covered it. This is the reason for the `fix:` type and not `bump:`.

## Verification

- All 23 patches apply.
- The four filters chain at index 0 of the constructor. Each filter removes only its own types, so the order does not matter.
- A whole-dex branch sweep of 648594 methods is clean.
- Device-confirmed on LINE 26.14.0.

## Base branch

This PR targets `bump/line-2614`, because that branch holds the 26.14.0 descriptors. GitHub retargets this PR to `dev` when PR #83 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)