### PR TITLE
feat: hide new item badges

### DIFF
--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidenewbadges/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidenewbadges/Fingerprints.kt
@@ -1,0 +1,220 @@
+package app.andrewliang.patches.line.hidenewbadges
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.fieldAccess
+import app.morphe.patcher.literal
+import app.morphe.patcher.methodCall
+
+private const val HEADER_BUTTON = "Ljp/naver/line/android/common/view/header/HeaderButton;"
+private const val HEADER_STATE_N = "Ljp/naver/line/android/common/view/header/a\$c;"
+
+/**
+ * The attach-menu badge enum (`DOT`, `EVENT`, `NEW`). Five unrelated enums in the APK also have a
+ * `DOT` constant, so the accessor fingerprint pins this type. The constant names survive R8; the
+ * type name does not, so re-confirm it on a version bump.
+ */
+private const val ATTACH_BADGE_ENUM = "Lk81/d\$b;"
+
+/**
+ * The Chats-tab header icon enum, and the set class its green-dot builder adds to. Both drift
+ * between versions. `chatheaderbuttons` and `hidecalendar` carry the same two descriptors.
+ */
+private const val HEADER_ICON_ENUM = "Lq11/n;"
+private const val GREEN_DOT_SET = "Lki8/j;"
+
+/**
+ * `HeaderButton.c(I, Z)V` — the **only** method in the whole APK that makes a header "new item"
+ * dot visible. The `Z` picks which of the two dot views to show, and it is a *theme* predicate
+ * (`o96.m.k()` = "custom theme applied || dark"), not a semantic distinction: green under a
+ * dark/custom theme, red otherwise. So one edit here removes the dot in both colours.
+ *
+ * Verified exhaustive: the dot view ids `0x7f0b1138` / `0x7f0b1139` are resolved to a view and
+ * given a visibility nowhere else. Nine call statements across seven feature areas funnel here —
+ * chat room (two buttons plus the hamburger), Home notification, Home settings, Album Note,
+ * Official Account list and Nearby (two).
+ *
+ * The numeric count badge is untouched: it is a different field, written directly by the count
+ * branch of `ag1.t1.i` without ever calling this method.
+ *
+ * Non-obfuscated class and method, so this anchor does not drift.
+ */
+internal object HeaderDotFingerprint : Fingerprint(
+    definingClass = HEADER_BUTTON,
+    name = "c",
+    returnType = "V",
+    parameters = listOf("I", "Z"),
+)
+
+/**
+ * The chat-room header badge renderer (obfuscated `ag1.t1.i`), matched on its **"N" badge branch**.
+ *
+ * The renderer switches over a sealed state with four cases — numeric count, dot, "N", and none —
+ * and only the "N" case reads `HeaderButton.g` (the `header_n_badge` view). Pairing the read of the
+ * non-obfuscated singleton `header/a$c` with the read of the non-obfuscated field
+ * `HeaderButton.g` lands on that method and nowhere else: `HeaderButton`'s own reads of `g` sit in
+ * a colour-filter helper and its constructor, neither of which mentions `a$c`.
+ *
+ * Both anchors are non-obfuscated, so this does not drift.
+ *
+ * The patch rewrites only the visibility argument of the following `setVisibility` call. It must
+ * NOT neuter the whole method — the numeric-count branch lives in the same method.
+ */
+internal object HeaderNBadgeFingerprint : Fingerprint(
+    returnType = "V",
+    filters = listOf(
+        fieldAccess(definingClass = HEADER_STATE_N, name = "a"),
+        fieldAccess(definingClass = HEADER_BUTTON, name = "g"),
+    ),
+)
+
+/**
+ * `LineUserSettingTextItemView.setNewBadgeVisible(Z)V` — the green "new" mark on a settings text
+ * row. Forcing the parameter false makes the existing body take its own hide branch, so no
+ * instruction shape is assumed beyond the signature. Non-obfuscated.
+ */
+internal object SettingsTextItemNewBadgeFingerprint : Fingerprint(
+    definingClass = "Lcom/linecorp/line/settings/base/itemview/LineUserSettingTextItemView;",
+    name = "setNewBadgeVisible",
+    returnType = "V",
+    parameters = listOf("Z"),
+)
+
+/**
+ * `LineUserSettingSwitchItemView.setIsNewMarkVisible(Z)V` — the same mark on a settings switch
+ * row. Same technique as [SettingsTextItemNewBadgeFingerprint]. Non-obfuscated.
+ */
+internal object SettingsSwitchItemNewMarkFingerprint : Fingerprint(
+    definingClass = "Lcom/linecorp/line/settings/base/itemview/LineUserSettingSwitchItemView;",
+    name = "setIsNewMarkVisible",
+    returnType = "V",
+    parameters = listOf("Z"),
+)
+
+/**
+ * The slide-out chat-menu row view holder, matched on its **constructor** because that is where the
+ * badge views are bound by resource id: `new_badge` (green dot, `0x7f0b18e9`) and
+ * `new_feature_badge` (the circled "N", `0x7f0b18f0`). Only this holder inflates both.
+ *
+ * Matching the constructor rather than the bind method lets the patch read the *field names* the
+ * two views are stored into, instead of hardcoding obfuscated field letters. Resource ids drift
+ * between LINE versions and must be re-resolved by name through `res/values/public.xml`.
+ */
+internal object ChatMenuRowHolderFingerprint : Fingerprint(
+    name = "<init>",
+    returnType = "V",
+    parameters = listOf("Landroid/view/View;"),
+    filters = listOf(
+        literal(0x7f0b18e9),
+        literal(0x7f0b18f0),
+    ),
+)
+
+/**
+ * The chat-menu **Album row** holder, matched on its constructor's bind of `new_album_badge`
+ * (`0x7f0b18e8`) — a green dot on its own layout, so it needs its own site. Same field-name
+ * discovery as [ChatMenuRowHolderFingerprint].
+ */
+internal object ChatMenuAlbumRowHolderFingerprint : Fingerprint(
+    name = "<init>",
+    returnType = "V",
+    parameters = listOf("Landroid/view/View;"),
+    filters = listOf(
+        literal(0x7f0b18e8),
+    ),
+)
+
+/**
+ * The Home/service badge enum's `<clinit>`, matched on its **constant names**, which R8 keeps.
+ * The enum carries a non-obfuscated `isVisible` field that ten call sites consult — Home service
+ * tiles, the service list sections, the top-services carousel and the shortcuts row — so forcing
+ * its accessor false clears all ten at once.
+ *
+ * `isVisible` alone is not unique (five classes have such a field), which is why the enum is
+ * located by its constants first and the accessor is then selected inside that class.
+ *
+ * Accepted trade: the enum also carries `EXPIRED`, arguably a warning rather than a "new item".
+ * Hiding it is the price of one edit instead of ten.
+ */
+internal object ServiceBadgeEnumFingerprint : Fingerprint(
+    name = "<clinit>",
+    returnType = "V",
+    filters = listOf(
+        fieldAccess(name = "NEW"),
+        fieldAccess(name = "UPDATE"),
+        fieldAccess(name = "EVENT"),
+        fieldAccess(name = "EXPIRED"),
+    ),
+)
+
+/**
+ * The shared friends/contacts row binder, matched on the R8-stable enum constant
+ * `GREEN_DOT_BADGE`. One binder serves every friend, group, directory and Square row plus the
+ * birthday row, so a single edit clears the green dot from all of them.
+ */
+internal object FriendRowGreenDotFingerprint : Fingerprint(
+    filters = listOf(
+        fieldAccess(name = "GREEN_DOT_BADGE"),
+        methodCall(definingClass = "Landroid/view/View;", name = "setVisibility"),
+    ),
+)
+
+/**
+ * The chat "+" attach-button dot gate, matched on the R8-stable attach badge constant `DOT`.
+ * Returns true when the plus-menu badge type is `DOT`; forcing it false clears the dot on the
+ * input bar.
+ */
+internal object AttachButtonDotFingerprint : Fingerprint(
+    returnType = "Z",
+    parameters = emptyList(),
+    filters = listOf(
+        fieldAccess(definingClass = ATTACH_BADGE_ENUM, name = "DOT"),
+    ),
+)
+
+/**
+ * The Chats-tab header green-dot set builder. It adds one header-icon enum constant per feature
+ * that currently has something new; the renderer then shows a green dot for any icon in the set.
+ * Emptying the set removes every Chats-tab header green dot.
+ *
+ * The filters pin the enum type and the `add` target, and they alternate constant and `add`. This
+ * is what keeps the enum `<clinit>` of the icon enum out of the match. That method writes the same
+ * constants with `sput-object`, and a blind two-instruction removal there would erase live code and
+ * leave null enum constants. `chatheaderbuttons` and `hidecalendar` pin the same two descriptors
+ * for the same reason.
+ *
+ * Each matched constant is immediately followed by its `add`, so the patch removes the pairs the
+ * same way `chatheaderbuttons` removes header buttons.
+ */
+internal object ChatsTabGreenDotSetFingerprint : Fingerprint(
+    filters = listOf(
+        fieldAccess(definingClass = HEADER_ICON_ENUM, name = "ALBUM"),
+        methodCall(definingClass = GREEN_DOT_SET, name = "add"),
+        fieldAccess(definingClass = HEADER_ICON_ENUM, name = "OPEN_CHAT"),
+        methodCall(definingClass = GREEN_DOT_SET, name = "add"),
+        fieldAccess(definingClass = HEADER_ICON_ENUM, name = "AI_FRIEND"),
+        methodCall(definingClass = GREEN_DOT_SET, name = "add"),
+    ),
+)
+
+/**
+ * The bottom-navigation button view holder, matched on its **constructor's bind of
+ * `bnb_button_badge_new`** (`0x7f0b03b5`) — the "new" badge ImageView.
+ *
+ * Matching the binder rather than the observer lambda is deliberate. The five observers that drive
+ * this button's badges (two unread counts, the count text, the live badge and the "new" badge) are
+ * near-identical one-line lambdas of the form "unwrap an Integer visibility, apply it to a view",
+ * and an earlier shape-based fingerprint for them matched an unrelated class in another feature
+ * entirely. Starting from the resource id gives the holder class and the exact field, and the
+ * observer is then found as the one class — instantiated by this holder — that reads that field.
+ *
+ * Resource ids drift between LINE versions and must be re-resolved by name through
+ * `res/values/public.xml`.
+ */
+internal object BottomNavBadgeHolderFingerprint : Fingerprint(
+    name = "<init>",
+    returnType = "V",
+    parameters = listOf("Landroid/view/ViewGroup;", "L", "L"),
+    filters = listOf(
+        literal(0x7f0b03b5),
+    ),
+)

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidenewbadges/HideNewBadgesPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidenewbadges/HideNewBadgesPatch.kt
@@ -1,0 +1,318 @@
+package app.andrewliang.patches.line.hidenewbadges
+
+import app.andrewliang.patches.shared.Constants.COMPATIBILITY_LINE
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.extensions.InstructionExtensions.removeInstructions
+import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
+import app.morphe.patcher.patch.PatchException
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.OffsetInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import com.android.tools.smali.dexlib2.iface.reference.TypeReference
+
+private const val HEADER_BUTTON = "Ljp/naver/line/android/common/view/header/HeaderButton;"
+
+/** `View.GONE`. Written into whichever register the matched `setVisibility` call reads. */
+private const val GONE = 0x8
+
+/** Maps a code offset to an instruction index, so a branch can be resolved to its target index. */
+private fun MutableMethod.offsetToIndex(): Map<Int, Int> {
+    val map = mutableMapOf<Int, Int>()
+    var offset = 0
+    implementation?.instructions?.forEachIndexed { index, instruction ->
+        map[offset] = index
+        offset += instruction.codeUnits
+    }
+    return map
+}
+
+/** Every instruction index that some branch in this method jumps to. */
+private fun MutableMethod.branchTargets(): Set<Int> {
+    val instructions = implementation?.instructions?.toList() ?: return emptySet()
+    val offsets = offsetToIndex()
+    val byIndex = offsets.entries.associate { (offset, index) -> index to offset }
+    return instructions.indices.mapNotNull { index ->
+        val instruction = instructions[index] as? OffsetInstruction ?: return@mapNotNull null
+        offsets[(byIndex[index] ?: return@mapNotNull null) + instruction.codeOffset]
+    }.toSet()
+}
+
+/**
+ * Forces the `setVisibility` call at [index] to hide its view.
+ *
+ * Two cases, because a branch can jump straight at the call:
+ *
+ * 1. The call is not a branch target. Inject `const/16 vD, GONE` in front of it. Only this call
+ *    site changes, and the registers the surrounding branches rely on keep their values.
+ * 2. The call **is** a branch target. Injecting in front of it would be a silent no-op:
+ *    `addInstruction` gives the new instruction its own `MethodLocation` and moves the existing
+ *    one, which owns the label, to the next index. The branch then jumps past the injection. This
+ *    is the shape LINE uses for a view that it shows or hides:
+ *
+ *        if-ne vState, vBadgeKind, :hide
+ *        move vD, vZero              # show
+ *        goto :call
+ *        :hide
+ *        const/16 vD, 0x8
+ *        :call
+ *        invoke-virtual {vC, vD}, Landroid/view/View;->setVisibility(I)V
+ *
+ *    The fix rewrites the producer on the show path: the instruction in front of the `goto` that
+ *    jumps to the call. Both paths then load GONE. `replaceInstruction` moves no label and shifts
+ *    no index.
+ */
+private fun MutableMethod.forceGoneAt(index: Int) {
+    val instructions = implementation?.instructions?.toList()
+        ?: throw PatchException("badges: no implementation for $definingClass")
+
+    val call = instructions.getOrNull(index)
+        ?: throw PatchException("badges: no instruction at $index in $definingClass")
+    val reference = (call as? ReferenceInstruction)?.reference as? MethodReference
+    if (reference?.name != "setVisibility") {
+        throw PatchException("badges: instruction $index in $definingClass is not setVisibility")
+    }
+    // setVisibility is always invoked as 35c. A /range form would carry its registers elsewhere,
+    // and silently reading the wrong operand is worse than failing here.
+    val visibilityRegister = (call as? FiveRegisterInstruction)?.registerD
+        ?: throw PatchException("badges: setVisibility at $index in $definingClass is not 35c")
+
+    if (index !in branchTargets()) {
+        addInstructions(index, "const/16 v$visibilityRegister, $GONE")
+        return
+    }
+
+    val offsets = offsetToIndex()
+    val byIndex = offsets.entries.associate { (offset, i) -> i to offset }
+    val gotoIndex = instructions.indices.firstOrNull { i ->
+        val instruction = instructions[i]
+        instruction.opcode in setOf(Opcode.GOTO, Opcode.GOTO_16, Opcode.GOTO_32) &&
+            offsets[(byIndex[i] ?: -1) + (instruction as OffsetInstruction).codeOffset] == index
+    } ?: throw PatchException(
+        "badges: setVisibility at $index in $definingClass is a branch target with no goto",
+    )
+
+    // The instruction in front of that goto must be what loads the visible value into vD.
+    val producer = instructions.getOrNull(gotoIndex - 1)
+    if ((producer as? OneRegisterInstruction)?.registerA != visibilityRegister) {
+        throw PatchException(
+            "badges: cannot find the show-path producer for setVisibility at $index " +
+                "in $definingClass",
+        )
+    }
+    replaceInstruction(gotoIndex - 1, "const/16 v$visibilityRegister, $GONE")
+}
+
+/** Every index in this method where a `setVisibility(I)V` is invoked on a view [isBadge] accepts. */
+private fun MutableMethod.visibilityCallsOn(isBadge: (FieldReference) -> Boolean): List<Int> {
+    val instructions = implementation?.instructions?.toList() ?: return emptyList()
+
+    // Receiver register -> the field it was last loaded from, tracked as we walk forward.
+    val loadedFrom = mutableMapOf<Int, String>()
+    val hits = mutableListOf<Int>()
+
+    instructions.forEachIndexed { index, instruction ->
+        if (instruction.opcode == Opcode.IGET_OBJECT) {
+            val field = (instruction as? ReferenceInstruction)?.reference as? FieldReference
+            val destination = (instruction as TwoRegisterInstruction).registerA
+            if (field != null && isBadge(field)) {
+                loadedFrom[destination] = field.name
+            } else {
+                loadedFrom.remove(destination)
+            }
+            return@forEachIndexed
+        }
+
+        // Any other write to a tracked register makes the mapping stale. move-object,
+        // move-result-object, sget-object, new-instance and check-cast all reuse registers, and a
+        // stale entry would hide whatever view the register holds later - a whole row, not a badge.
+        (instruction as? OneRegisterInstruction)?.let { loadedFrom.remove(it.registerA) }
+
+        val reference = (instruction as? ReferenceInstruction)?.reference as? MethodReference
+        if (reference?.name != "setVisibility") return@forEachIndexed
+        val receiver = (instruction as? FiveRegisterInstruction)?.registerC ?: return@forEachIndexed
+        if (loadedFrom[receiver] != null) hits += index
+    }
+    return hits
+}
+
+@Suppress("unused")
+val hideNewBadgesPatch = bytecodePatch(
+    name = "Hide new item badges",
+    description = "Hides the green dots and N badges that mark new items, on header buttons, " +
+        "tabs, menus, lists and settings rows. Unread message counts do not change.",
+    default = true,
+) {
+    compatibleWith(COMPATIBILITY_LINE)
+
+    execute {
+        // ---- Core sites. These resolve strictly: they are the badges the patch exists for, and
+        // every anchor below is a non-obfuscated class, method or field, so none of them drifts.
+
+        // 1. Every header "new item" dot, in both theme colours: 9 call statements across 7
+        //    feature areas funnel into HeaderButton.c(I, Z). Keep the existing b() reset call so a
+        //    recycled button cannot keep a stale badge, then return before either dot is shown.
+        //    `.locals 0`, so p0 is the only register needed.
+        // b() hides every badge view in the button's own set. Its name is R8-assigned, so make
+        // sure it exists at patch time: dexlib assembles a reference to a missing method without
+        // complaint, and the failure would then be a runtime NoSuchMethodError on every badge
+        // update instead of a failed patch.
+        val headerButton = mutableClassDefBy(HEADER_BUTTON)
+        if (headerButton.methods.none {
+                it.name == "b" && it.returnType == "V" && it.parameterTypes.isEmpty()
+            }
+        ) {
+            throw PatchException("badges: $HEADER_BUTTON->b()V not found")
+        }
+        HeaderDotFingerprint.method.addInstructions(
+            0,
+            """
+                invoke-virtual {p0}, $HEADER_BUTTON->b()V
+                return-void
+            """,
+        )
+
+        // 2. The circled "N" on the chat-room header. Rewrite only the visibility argument of the
+        //    setVisibility that follows the read of HeaderButton.g — the numeric-count branch is
+        //    in this same method and must keep working.
+        val nBadgeFieldReadIndex = HeaderNBadgeFingerprint.instructionMatches[1].index
+        HeaderNBadgeFingerprint.method.forceGoneAt(nBadgeFieldReadIndex + 1)
+
+        // 3-4. Settings rows. Forcing the parameter false makes each setter take its own hide
+        //      branch, so no instruction shape is assumed beyond the signature.
+        SettingsTextItemNewBadgeFingerprint.method.addInstructions(0, "const/4 p1, 0x0")
+        SettingsSwitchItemNewMarkFingerprint.method.addInstructions(0, "const/4 p1, 0x0")
+
+        // ---- Best-effort sites. Each anchors on a resource id or an R8-stable enum constant, but
+        // the enclosing classes are obfuscated. A drifted anchor skips its own surface instead of
+        // failing the whole patch, so the core badges above always ship.
+
+        // 5-6. Chat slide-out menu rows: the green dot and the circled-N feature badge, plus the
+        //      Album row's own green dot. The badge views are found by the resource id their
+        //      constructor binds, so no obfuscated field letter is hardcoded.
+        listOf(
+            ChatMenuRowHolderFingerprint to listOf(0x7f0b18e9, 0x7f0b18f0),
+            ChatMenuAlbumRowHolderFingerprint to listOf(0x7f0b18e8),
+        ).forEach { (fingerprint, badgeIds) ->
+            val constructor = fingerprint.methodOrNull ?: return@forEach
+            val matches = fingerprint.instructionMatchesOrNull ?: return@forEach
+
+            // Each matched literal is followed by findViewById and an iput-object into the field
+            // that holds that badge view. Collect those field names.
+            val constructorInstructions = constructor.implementation?.instructions?.toList()
+                ?: return@forEach
+            val badgeFields: Set<FieldReference> = matches.mapNotNull { match ->
+                (match.index until constructorInstructions.size)
+                    .firstOrNull { constructorInstructions[it].opcode == Opcode.IPUT_OBJECT }
+                    ?.let {
+                        (constructorInstructions[it] as ReferenceInstruction).reference
+                            as? FieldReference
+                    }
+            }.toSet()
+            if (badgeFields.size != badgeIds.size) return@forEach
+
+            val holder = mutableClassDefBy(constructor.definingClass)
+            holder.methods.forEach { method ->
+                // Walk backwards so injecting does not shift the indices still to be patched.
+                method.visibilityCallsOn { field ->
+                    badgeFields.any {
+                        field.definingClass == it.definingClass && field.name == it.name
+                    }
+                }
+                    .reversed().forEach(method::forceGoneAt)
+            }
+        }
+
+        // 7. Home service tiles, the service list and the shortcuts row — ten call sites read one
+        //    `isVisible` accessor on a shared badge enum. The enum is located by its R8-stable
+        //    constant names, then the accessor is selected inside it by shape.
+        ServiceBadgeEnumFingerprint.methodOrNull?.let { clinit ->
+            val badgeEnum = mutableClassDefBy(clinit.definingClass)
+            badgeEnum.methods.firstOrNull { method ->
+                method.returnType == "Z" &&
+                    method.parameterTypes.isEmpty() &&
+                    method.implementation?.instructions?.any {
+                        ((it as? ReferenceInstruction)?.reference as? FieldReference)
+                            ?.name == "isVisible"
+                    } == true
+            }?.addInstructions(
+                0,
+                """
+                    const/4 p0, 0x0
+                    return p0
+                """,
+            )
+        }
+
+        // 8. Friends and contacts rows: one shared binder draws the green dot for every friend,
+        //    group, directory, Square and birthday row.
+        FriendRowGreenDotFingerprint.methodOrNull?.let { method ->
+            val setVisibilityIndex = FriendRowGreenDotFingerprint
+                .instructionMatchesOrNull?.getOrNull(1)?.index ?: return@let
+            method.forceGoneAt(setVisibilityIndex)
+        }
+
+        // 9. The dot on the chat "+" attach button.
+        AttachButtonDotFingerprint.methodOrNull?.addInstructions(
+            0,
+            """
+                const/4 v0, 0x0
+                return v0
+            """,
+        )
+
+        // 10. Chats-tab header green dots: empty the set of icons that get a dot by removing each
+        //     `sget-object <constant>` and the `add` that follows it. Highest index first, so the
+        //     earlier pairs keep their positions.
+        ChatsTabGreenDotSetFingerprint.methodOrNull?.let { method ->
+            // Matches alternate constant, add. Take the constant indices only, and remove each
+            // pair from the highest index down so the earlier pairs keep their positions.
+            ChatsTabGreenDotSetFingerprint.instructionMatchesOrNull
+                ?.filterIndexed { position, _ -> position % 2 == 0 }
+                ?.map { it.index }
+                ?.sortedDescending()
+                ?.forEach { method.removeInstructions(it, 2) }
+        }
+
+        // 11. The bottom-navigation "new" badge. Its observer is one of five near-identical
+        //     one-line lambdas on this holder — the others drive the unread counts, the count text
+        //     and the live badge — so it is found by data flow rather than by shape: take the field
+        //     the holder binds `bnb_button_badge_new` into, then patch the one class the holder
+        //     instantiates that reads that exact field. An earlier shape-only fingerprint matched
+        //     an unrelated class in another feature, which is why this is derived, not guessed.
+        BottomNavBadgeHolderFingerprint.methodOrNull?.let { constructor ->
+            val literalIndex = BottomNavBadgeHolderFingerprint
+                .instructionMatchesOrNull?.firstOrNull()?.index ?: return@let
+            val instructions = constructor.implementation?.instructions?.toList() ?: return@let
+
+            val badgeField = (literalIndex until instructions.size)
+                .firstOrNull { instructions[it].opcode == Opcode.IPUT_OBJECT }
+                ?.let {
+                    ((instructions[it] as ReferenceInstruction).reference as? FieldReference)
+                } ?: return@let
+
+            val holder = mutableClassDefBy(constructor.definingClass)
+            val observerTypes = holder.methods
+                .flatMap { it.implementation?.instructions?.toList().orEmpty() }
+                .filter { it.opcode == Opcode.NEW_INSTANCE }
+                .mapNotNull { ((it as ReferenceInstruction).reference as? TypeReference)?.type }
+                .distinct()
+
+            observerTypes.forEach { type ->
+                val observer = runCatching { mutableClassDefBy(type) }.getOrNull() ?: return@forEach
+                observer.methods.forEach { method ->
+                    method.visibilityCallsOn { field ->
+                        field.definingClass == badgeField.definingClass &&
+                            field.name == badgeField.name
+                    }.reversed().forEach(method::forceGoneAt)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What this does

Add the patch "Hide new item badges". The patch hides the "there is something new here" indicators of LINE across the app. **Unread counts do not change.**

The work started from a red circled "N" beside the chat-room hamburger. That badge is not patch residue, and it is not the hidden Calendar button. It is an indicator of LINE.

## Covered surfaces

Each edit is at a shared choke point, not at each row:

- Header buttons. `HeaderButton.c(I,Z)` is the only method in the APK that shows a header dot. One edit clears 9 call statements in 7 feature areas.
- The circled "N" beside the chat-room hamburger.
- The chat slide-out menu rows: the green dot and the feature badge.
- The Album row of the chat menu.
- The dot on the chat "+" button.
- The green dots on the Chats-tab header.
- The friends and contacts rows.
- The Home service tiles. One enum accessor covers the ten call sites.
- The settings text rows and the settings switch rows.
- The new badge of the bottom navigation.

The dot has one indicator and two colours. The boolean of `HeaderButton.c(I,Z)` is a theme predicate, not a semantic one. It selects green under a dark or custom theme, and red in other themes. As a result, one edit covers both colours.

## Unread counts

The patch keeps every unread count by design. The count badge is a different field, and its code path never calls the method that this patch neuters. The counts of the bottom navigation are TextView fields, but the new badge is an ImageView.

## Anchors

Four sites use non-obfuscated classes. The other sites use names that R8 keeps, such as the enum constants `GREEN_DOT_BADGE` and `DOT`, or resource IDs. The patch reads the badge field names from the binding constructor instead of a hardcoded value.

The four non-obfuscated sites resolve strictly. The other sites are best-effort, so a drifted anchor skips only its own surface.

## One trade

The Home service enum also carries `EXPIRED`, which is a warning and not a new item. One edit for ten sites is worth this cost.

## A bug that this PR corrects

An earlier fingerprint for the bottom-navigation observer used instruction shape only. Five near-identical lambdas matched it, and the patch changed an unrelated class with no error. The apply step reported success.

The fingerprint now takes the holder and the field from the resource ID of the badge. It then patches the one class that reads that field. The unrelated class is untouched. The three sibling observers for the counts and the live badge are also untouched.

## Verification

- All 24 patches apply.
- We disassembled and checked every site.
- A whole-dex branch sweep of 648594 methods is clean.
- Device-confirmed on LINE 26.14.0. The unread counts still show.

## Base branch

This PR targets `bump/line-2614`, because that branch holds the 26.14.0 descriptors. GitHub retargets this PR to `dev` when PR #83 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)