### PR TITLE
feat: draw the location maps through GmsCore (issue #92)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,32 @@ Re-signing (Standard install) breaks push while the app is *fully closed*. Unlik
 - **Which cert:** `base.apk` uses APK Signature Scheme **v3.1 key rotation** (two certs) and `GET_SIGNATURES` returns the lineage-**root** one, so the patch injects the SDK 24–32 signer `89396DC419292473972813922867E6973D6F5C50`. Fallback if `BAD CONFIG` persists: the rotated SDK 33+ signer `6A2927D945AEA6571E1DA5566802F25045D367BD`. Re-derive both with `apksigner verify --print-certs base.apk` on a version bump — 26.14.0 carries the same v3.1 lineage, so both hashes are unchanged and this patch needed no edit.
 - **Verify:** disassemble `ct/c` — `const-string v$reg, "<sha1>"` must land in the `addRequestProperty` value register (`registerE`) right before the `X-Android-Cert` send. On device, `PersistedInstallation*.json` `Status` should flip `4 → 3` (REGISTERED). **The on-device flip is the real proof;** disassembly only shows the header was rewritten.
 
+### Re-signed builds & empty location maps (fixed by "Fix location maps via GmsCore")
+
+Third member of the re-signing family, and the one where **no certificate fix exists**. Full detail
+in `docs/line-patch-map.md` ("Location maps") — read it before touching this.
+
+- **Symptom:** every map draws as an empty grid on a re-signed build — picker, both chat bubbles,
+  viewer, Notes and Timeline posts (**eight layouts**). The GPS fix still works and can still be
+  sent, because it comes from the framework `LocationManager`, not Play Services.
+- **Why unfixable by certificate:** LINE ships only the Maps SDK v2 thin client. `fo/p.b` loads the
+  renderer out of Play Services via `DynamiteModule`; the renderer then binds `ApiTokenService`
+  **in the Play Services process**, which reads the real certificate itself. Contrast
+  `fixpushnotifications`, where LINE's own code builds the header — that is why one is patchable and
+  this is not.
+- **The fix:** hand `fo/p.b` MicroG-RE's context (`createPackageContext`), whose bundled MapLibre
+  renderer validates no key. MicroG-RE added Maps *for this redirect*. Returns `null` without
+  MicroG-RE, so the patch is a no-op rather than a new failure.
+- **Needs MicroG-RE 7.0.0+ AND real Play Services.** The renderer landed in 7.0.0, so the 6.1.4
+  that `gmscoreauth` documents has the package but no `CreatorImpl` — the extension loads that
+  class before it returns the context, because otherwise `fo/p.c` returns null and `fo/p.a` NPEs.
+  And `fo/p.a` gates on `am/j.e(Context, 0xcc77c0)` first, which only real Play Services satisfies.
+- **Do not** rewrite `DynamiteModule`'s own `"com.google.android.gms"` literal — it is shared with
+  ads, vision, ML Kit and TFLite. Redirect the one call site, as `gmscoreauth` does for `kl.d.E()`.
+- **Tradeoff:** OpenFreeMap tiles, no satellite view. `default = true`, and it only acts when
+  MicroG-RE is installed — so the one group that loses is a Root Mount user who installed MicroG-RE
+  for chat backup, whose working Google tiles get replaced. They must turn the patch off.
+
 ### Known limitation: Google account sign-in on re-signed builds
 
 Also documented user-facing as a "Known limitation" in `README.md` — update both together. Same *class* of cause as the FCM break (Google config pinned to LINE's official cert SHA-1) but a distinct mechanism, and only half fixable. Device-confirmed on LINE 26.11.0 / Android 16; not a patch bug. **Full investigation, anchors and the GmsCore route in `docs/line-patch-map.md` — read it before touching this; do not re-derive.**

--- a/README.md
+++ b/README.md
@@ -86,6 +86,23 @@ Google Play Services. No patch can change this ([details](docs/line-patch-map.md
 This limitation does not affect chat-history backup. The *Fix chat backup sign-in via GmsCore*
 patch restores it through [MicroG-RE](https://github.com/MorpheApp/MicroG-RE).
 
+### LINE: maps show an empty grid (re-signed builds)
+
+**What:** On a patched **LINE** build, the maps on the location screens are empty. This covers the
+location picker, the location messages in a chat, and the location posts. You can still send your
+current location, and only the map is blank.
+
+**Why:** Google draws a map only for an API key that is registered under LINE's package name **and**
+its original signing certificate. A re-signed build changes that certificate. Google Play Services
+reports the certificate from its own process, so no patch can correct it
+([details](docs/line-patch-map.md)).
+
+**Workaround:** enable the *Fix location maps via GmsCore* patch. It draws the maps through
+[MicroG-RE](https://github.com/MorpheApp/MicroG-RE) **7.0.0 or later** instead, which is the first
+version with a map renderer. Google Play Services must still be installed. The tiles then come from OpenFreeMap,
+so they do not look like Google Maps. There is no satellite view. A **Root Mount** install keeps
+LINE's original signature and needs neither the patch nor MicroG-RE.
+
 ## 🙏 Special thanks
 
 - [@f870103](https://github.com/f870103) — lent a LINE account for tests, and found the redirect URL of the LINE Pay app.

--- a/docs/line-patch-map.md
+++ b/docs/line-patch-map.md
@@ -495,10 +495,11 @@ starting point, so no one needs to sweep the APK again.
 | Redirect LINE Pay | `line.disablepay` | `PayLaunchActivity` / `PayLiffActivity` onCreate (see below) |
 | Keep unsent messages | `line.keepunsent` | `la8.x.invoke` — the unsend DB write (see below) |
 | Hide Shopping tab | `line.hideshoppingtab` | `COMMERCE` + `COMMERCE_TW` in `wy7.b.a()` (see above) |
+| Fix location maps via GmsCore | `line.fixlocationmaps` | `fo/p.b` — the maps module context (see below) |
 
-Each is an independent, `default = true`, user-facing `bytecodePatch` — one feature (or one feature's
-full set of entry points) per patch. Most are instruction-level edits; *Redirect LINE Pay* and *Keep
-unsent messages* carry extension code.
+Each is an independent, `default = true`, user-facing `bytecodePatch` — one feature (or one
+feature's full set of entry points) per patch. Most are instruction-level edits. *Redirect LINE
+Pay*, *Keep unsent messages* and *Fix location maps* carry extension code.
 
 ## LINE Pay intake & the "Redirect LINE Pay" patch
 
@@ -1052,8 +1053,10 @@ class `com.google.android.gms.auth.GetToken` inside the `app.revanced` package. 
 name too binds a component that does not exist — LINE shows a generic access error with **nothing in
 the log**, because no service starts.
 
-Everything else keeps talking to real Play Services — Maps, location sharing, ML Kit, FCM, anything
-Pay touches — so the "Play Services missing" checks a wholesale GmsCore patch must defeat never fire.
+Everything else keeps talking to real Play Services — ML Kit, FCM, anything Pay touches — so the
+"Play Services missing" checks a wholesale GmsCore patch must defeat never fire. Maps is the one
+other surface that can be moved, by its own opt-in patch and through a different mechanism
+(`DynamiteModule`, not a GMS client) — see "Location maps" below.
 
 Also required and easy to forget: a `<queries>` entry for GmsCore (LINE is `targetSdk 30+`, so without
 it every lookup fails as "package not found"), and **not** renaming LINE's package (below).
@@ -1117,6 +1120,151 @@ hard-requires do **not** resolve against LINE: `GooglePlayUtilityFingerprint` (n
 `MetadataValueReader` string LINE does not ship) and `ServiceCheckFingerprint` (LINE's only
 `"Google Play Services not available"` match is a constructor in `gl.h`). For LINE neither is
 needed anyway — real Play Services is installed, so the "GMS missing" checks never trigger.
+
+## Location maps & the "Fix location maps via GmsCore" patch
+
+Reported as issue #92 ("share location doesn't work"). On a re-signed build every map draws as an
+empty grid. The current location is still found and can still be sent, and only the map is blank.
+A Root Mount install keeps LINE's signature, so it never shows the problem.
+
+### The third re-signing break, and the only one with no certificate fix
+
+| | Push notifications | Google sign-in | **Location maps** |
+|---|---|---|---|
+| What Google checks | the Firebase API key against the cert | the OAuth client against the cert | the Maps API key against the cert |
+| Who reports the cert | **LINE's own** bundled FIS code | Play Services | **Play Services** |
+| Error | `FisError: BAD CONFIG` | `UNREGISTERED_ON_API_CONSOLE` | `Authorization failure` |
+| Fix | rewrite the header (`fixpushnotifications`) | none | redirect the renderer |
+
+LINE ships only the Maps SDK v2 **thin client** — six stub classes under
+`com/google/android/gms/maps/` plus obfuscated delegates in `eo/` and `fo/`. The renderer is not in
+the APK. `fo/p.b` asks `DynamiteModule` for the maps module and gets a remote `Context`; `fo/p.c`
+then class-loads `com.google.android.gms.maps.internal.CreatorImpl` out of it. That renderer runs
+**inside LINE's process**, but it binds `com.google.android.gms.maps.auth.ApiTokenService` **in the
+Play Services process**, which reads LINE's real signing certificate from `PackageManager` and asks
+Google's server for a tile token.
+
+So the key is ours to change but the certificate is not: it is read in another process, and the
+decision is made server-side. This is the opposite of `fixpushnotifications`, where LINE's own code
+builds the `X-Android-Cert` header. **Nothing in LINE's dex reports the certificate, so no patch can
+correct it.** The API key itself sits at `res/values/strings.xml` (`google_maps_key`), reached from
+the manifest `com.google.android.geo.API_KEY` meta-data — a user-supplied key of their own would
+also work, but it costs each user a Google Cloud project with billing enabled, so no patch does that.
+
+### It is eight surfaces, not one
+
+Every layout that inflates a Maps view breaks together, which is why the report said "or sent to
+chat" — the message bubble looks broken too:
+
+| Layout | Surface |
+|---|---|
+| `select_location_activity.xml` (`SupportMapFragment`) | the location picker; `SelectLocationActivity` |
+| `location_viewer.xml` (`SupportMapFragment`) | full-screen viewer; `LocationViewerActivity` |
+| `chat_ui_row_send_msg_location.xml` (`MapView`) | outgoing location bubble in a chat |
+| `chat_ui_row_receive_msg_location.xml` (`MapView`) | incoming location bubble in a chat |
+| `note_post_media_location.xml`, `note_home_write_location_media_layout.xml` | Notes location posts |
+| `post_media_location.xml`, `timeline_write_location_media_layout.xml` | Timeline/VOOM location posts |
+
+All eight go through the one renderer, so one redirect fixes all of them.
+
+**Why "send current location" survives:** the fix comes from the framework
+`android.location.LocationManager` (wrapper `jp/naver/line/android/service/f`). LINE bundles **no**
+`FusedLocationProviderClient` — the `com.google.android.gms.location.*` classes it carries are value
+types only. Tiles and coordinates are independent paths, so one can fail while the other works.
+
+### What the patch does
+
+MicroG-RE added a Maps renderer **for exactly this redirect** (its PR #187; PR #219 then put all
+three renderers in one APK, selectable at runtime, and added a keyless **OpenFreeMap** fallback).
+Its `CreatorImpl` keeps the legacy fully-qualified name on purpose, because clients look it up by
+that name inside MicroG's classloader. The renderer validates no key and no signature.
+
+`fo/p.b(Context, eo/d$a)Landroid/content/Context;` is the one choke point — all three of its callers
+are inside `fo/p`. The patch prepends four instructions:
+
+```smali
+invoke-static { p0 }, Lapp/andrewliang/extension/LocationMaps;->getMapsContext(Landroid/content/Context;)Landroid/content/Context;
+move-result-object v0
+if-eqz v0, :original     # ExternalLabel bound to the original first instruction
+return-object v0
+```
+
+The extension returns MicroG-RE's context via
+`createPackageContext("app.revanced.android.gms", CONTEXT_INCLUDE_CODE | CONTEXT_IGNORE_SECURITY)`,
+or `null` when MicroG-RE is absent — and then the branch falls into the original body and LINE keeps
+using Play Services. **So the patch is a no-op without MicroG-RE**, never a new failure.
+
+Four things that made this safe, and are worth keeping:
+
+- **The package alone is not enough — load the class.** MicroG-RE only got a Maps renderer in
+  **7.0.0** (2026-09-01). An older build has the package but no `CreatorImpl`, and then
+  `createPackageContext` succeeds while `fo/p.c`'s `loadClass` throws `ClassNotFoundException`,
+  hits `:catch_2` and returns the `const/4 v0, 0x0` it set at the top — **null**. `fo/p.a` then
+  does `invoke-interface {v1}, Lfo/r;->d()I` inside a try that catches only `RemoteException`, so
+  the null renderer is an **uncaught NPE**: the patch would turn a blank map into a crash. This
+  matters because **6.1.4 is the version `gmscoreauth` documents** for chat backup, and it is
+  older than the renderer. The extension therefore loads `CreatorImpl` itself before it returns
+  the context, and returns `null` when the class is missing.
+- **`v0` is free at index 0.** The method is `.locals 1`, and its own first instruction is
+  `sget-object v0, Lfo/p;->a`, so nothing reads what the injection leaves in `v0`.
+- **The extension caches the miss as well as the hit.** LINE caches the module context in the
+  static `Lfo/p;->a`, and the early return skips that store. The injection also runs *before*
+  LINE's own cache check, so without a remembered miss every call would repeat a failing
+  `createPackageContext` and log a stack trace.
+- **`DynamiteModule` is left alone.** Its own `"com.google.android.gms"` literal
+  (`DynamiteModule.smali:1887` and `:2599`) is shared by every dynamite consumer — ads, vision,
+  ML Kit barcode/OCR/face, TFLite. Rewriting it would send all of them to MicroG-RE. Same trap as
+  `kl.d.E()` for the GMS clients: redirect the one call site, not the shared resolver.
+
+**Real Play Services must still be installed.** `fo/p.b` is not the first gate. `fo/p.a` — the
+entry point all three `eo/*` callers use — first runs `am/j.e(Context, 0xcc77c0)` (Play Services
+13.4) and throws `am.g` (`GooglePlayServicesNotAvailableException`) before `b` is ever reached.
+`am/j.e` looks for the literal package `com.google.android.gms`, which MicroG-RE does not claim. So
+on a de-Googled device that has only MicroG-RE, this patch does nothing and the map stays blank —
+silently, because `eo/d` catches `am.g`. The patch needs **both** real Play Services and MicroG-RE
+7.0.0+.
+
+**One LINE fallback is neutered, deliberately.** `fo/p.a`'s `:catch_1` handles
+`UnsatisfiedLinkError` by resetting `Lfo/p;->a` to null and calling `c(ctx, LEGACY)` to retry with
+the legacy renderer. The patched `b` ignores `p1` and returns the extension's own static cache, so
+that retry gets the same MicroG renderer. If MicroG's MapLibre native library ever fails to load,
+there is no second chance. Accepted: the alternative is a reset hook for a case no device has shown.
+
+**A risk that turned out to be already handled.** MicroG-RE declares a `ModuleDescriptor` for
+`maps_dynamite` only, while modern clients prefer `maps_core_dynamite`. LINE's own body already
+catches that failure and retries `maps_dynamite`, then falls back to `getRemoteContext` — so even a
+plain package redirect would have worked. Bypassing `DynamiteModule` avoids the question entirely.
+
+**Tradeoff:** tiles come from OpenFreeMap through MapLibre, so they do not look like Google Maps,
+there is no satellite view, and Street View is stubbed. Upstream microG rates this renderer "mostly"
+complete with minor glitches.
+
+The patch is `default = true`. It only does something when MicroG-RE is installed, so most users
+either get a working map or no change at all. **One group loses something:** a Root Mount user who
+installed MicroG-RE for chat backup already has working Google tiles, and this patch replaces them
+with OpenFreeMap ones. That user must turn the patch off.
+
+### Values that drift on a version bump
+
+| What | 26.14.0 | How to re-find it |
+|---|---|---|
+| Maps module loader | `fo/p.b(Context, eo/d$a)` | The four string anchors below all live in this method. |
+| Renderer creator loader | `fo/p.c(Context, eo/d$a)` | Loads `…maps.internal.CreatorImpl` by name. |
+| Renderer preference enum | `eo/d$a` (`LEGACY`) | Left unpinned by the fingerprint on purpose. |
+| Anchors (stable) | `com.google.android.gms.maps_legacy_dynamite`, `…maps_core_dynamite`, `…maps_dynamite`, `Unable to load maps module, maps container context is null` | These belong to Google's bundled Maps client, not to LINE, so they survive LINE's obfuscation. |
+| MicroG-RE package | `app.revanced.android.gms` | Namespace stays `com.google.android.gms`. |
+
+**Not yet device-confirmed.** Verified statically only: the fingerprint resolves against 26.14.0,
+the four injected instructions sit at index 0 with the branch bound to the original first
+instruction, both `.catch` ranges rebase correctly, and a whole-APK offset sweep (648,591 methods,
+14 dex files) is clean. Still to check on a device with MicroG-RE 7.1.0 installed:
+
+1. All four visible surfaces draw tiles, and the picker pans and repositions its pin.
+2. `logcat -s "Google Android Maps SDK"` no longer prints `Ensure that the following Android Key
+   exists`, and `logcat -s AndrewLineMaps` prints "Loading maps from MicroG-RE."
+3. **QR / barcode scanning still works** — this is what proves leaving `DynamiteModule` alone kept
+   ML Kit on real Play Services. The most important regression check.
+4. Without MicroG-RE installed, the build behaves exactly as an unpatched one (blank map, no crash).
 
 ## Watch list — surfaced in 26.14.0, not yet actionable
 

--- a/extensions/extension/src/main/java/app/andrewliang/extension/LocationMaps.java
+++ b/extensions/extension/src/main/java/app/andrewliang/extension/LocationMaps.java
@@ -1,0 +1,91 @@
+package app.andrewliang.extension;
+
+import android.content.Context;
+import android.util.Log;
+
+/**
+ * Helper for the "Fix location maps via GmsCore" patch.
+ *
+ * <p>LINE draws every map through the Google Maps Android SDK v2 <i>thin client</i>. The renderer
+ * itself is not in LINE's APK: LINE asks {@code DynamiteModule} for
+ * {@code com.google.android.gms.maps_dynamite}, receives a remote {@link Context}, and class-loads
+ * {@code com.google.android.gms.maps.internal.CreatorImpl} out of it. That renderer then binds
+ * {@code com.google.android.gms.maps.auth.ApiTokenService} <b>in the Play Services process</b>,
+ * which reads LINE's real signing certificate from {@code PackageManager} and asks Google's server
+ * for a tile token. On a re-signed build the certificate no longer matches the restriction on
+ * LINE's API key, the token is refused, and every map renders as an empty grid.
+ *
+ * <p>Nothing in LINE's own bytecode reports that certificate, so it cannot be corrected the way
+ * "Fix push notifications" rewrites the {@code X-Android-Cert} header. Instead this returns
+ * MicroG-RE's {@link Context}, whose bundled MapLibre/VTM renderer validates no key and no
+ * signature. MicroG-RE added Maps support for exactly this redirect.
+ *
+ * <p>Returns {@code null} when MicroG-RE is not installed, which makes the patch a no-op: LINE
+ * falls through to its original body and keeps talking to real Play Services. Only the maps module
+ * context is redirected — {@code DynamiteModule} itself is untouched, so ads, ML Kit and TFLite
+ * still load from Play Services.
+ */
+public final class LocationMaps {
+
+    private LocationMaps() {}
+
+    private static final String TAG = "AndrewLineMaps";
+
+    /** MicroG-RE's applicationId. Its namespace stays {@code com.google.android.gms}. */
+    private static final String MICROG_PACKAGE = "app.revanced.android.gms";
+
+    /**
+     * The class LINE loads by name out of the module context. MicroG-RE keeps this exact name on
+     * purpose. It is also the test for whether a given MicroG-RE build has a Maps renderer at all.
+     */
+    private static final String CREATOR_CLASS = "com.google.android.gms.maps.internal.CreatorImpl";
+
+    /**
+     * The result of the one attempt, or {@code null} when there is no usable renderer.
+     *
+     * <p>LINE stores the module context in a static field and returns it on later calls. The patch
+     * returns before that store, so without a cache here every map would rebuild the context.
+     */
+    private static Context cached;
+
+    /** Set after the first attempt, so a miss costs no more than a hit. */
+    private static boolean tried;
+
+    /**
+     * MicroG-RE's context, with its code loaded, or {@code null} when it cannot draw a map.
+     *
+     * @param context any LINE context; only used to reach the package manager.
+     */
+    public static Context getMapsContext(Context context) {
+        if (tried) return cached;
+        if (context == null) return null;
+        tried = true;
+
+        try {
+            // CONTEXT_INCLUDE_CODE loads MicroG-RE's classes and native libraries into LINE's
+            // process, which is where the renderer has to run. IGNORE_SECURITY is required
+            // because the two apps are signed with different certificates.
+            Context microG = context.createPackageContext(
+                MICROG_PACKAGE,
+                Context.CONTEXT_INCLUDE_CODE | Context.CONTEXT_IGNORE_SECURITY
+            );
+
+            // MicroG-RE only got a Maps renderer in 7.0.0. An older build has the package but not
+            // the class, and the package alone is not enough: LINE's loader would take this
+            // context, fail to load the class, return null, and then crash on the null renderer.
+            // Load the class here instead, so an older build falls back to Play Services.
+            microG.getClassLoader().loadClass(CREATOR_CLASS);
+
+            cached = microG;
+            Log.i(TAG, "Loading maps from MicroG-RE.");
+        } catch (Throwable t) {
+            // NameNotFoundException: MicroG-RE is not installed, or LINE cannot see it because the
+            // manifest <queries> entry is missing. ClassNotFoundException: MicroG-RE is older than
+            // 7.0.0. Either way, leave the map to Play Services rather than break it further.
+            cached = null;
+            Log.w(TAG, "MicroG-RE maps unavailable; leaving maps on Play Services.", t);
+        }
+
+        return cached;
+    }
+}

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/fixlocationmaps/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/fixlocationmaps/Fingerprints.kt
@@ -1,0 +1,42 @@
+package app.andrewliang.patches.line.fixlocationmaps
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.string
+import com.android.tools.smali.dexlib2.AccessFlags
+
+/**
+ * `fo/p.b(Context, eo/d$a)` — resolves the **maps module context**, the one choke point every LINE
+ * map goes through.
+ *
+ * The body caches the result in a static field, and otherwise asks `DynamiteModule` for the
+ * renderer: `maps_core_dynamite` (or `maps_legacy_dynamite` when the caller asked for the legacy
+ * renderer), falling back to `maps_dynamite` and finally to `getRemoteContext`. `fo/p.c` then
+ * class-loads `com.google.android.gms.maps.internal.CreatorImpl` from whatever context comes back.
+ *
+ * Its only three callers all live in `fo/p`, so redirecting this method covers the picker, the
+ * viewer, both chat bubbles, and the Notes and Timeline location posts at once.
+ *
+ * Anchored on the three dynamite module names plus the failure string, all four of which sit in
+ * this method. They belong to Google's bundled Maps client rather than to LINE's own code, so they
+ * survive LINE's obfuscation and its version bumps. `fo/p` itself drifts, so it is never named.
+ *
+ * The first parameter is pinned because the patch injects `invoke-static { p0 }` against a
+ * `(Landroid/content/Context;)` signature. If a bump ever reorders the parameters, this makes the
+ * fingerprint stop resolving — a clean failure — instead of emitting a type-incorrect invoke that
+ * fails class verification at run time. The second entry is the bare `L` prefix, because the
+ * renderer-preference enum `eo/d$a` does drift and the patch never reads it.
+ *
+ * [instructionMatches] in program order: the legacy module name, the core module name, the
+ * `maps_dynamite` fallback, then the "container context is null" log string.
+ */
+internal object MapsModuleContextFingerprint : Fingerprint(
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.STATIC),
+    returnType = "Landroid/content/Context;",
+    parameters = listOf("Landroid/content/Context;", "L"),
+    filters = listOf(
+        string("com.google.android.gms.maps_legacy_dynamite"),
+        string("com.google.android.gms.maps_core_dynamite"),
+        string("com.google.android.gms.maps_dynamite"),
+        string("Unable to load maps module, maps container context is null"),
+    ),
+)

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/fixlocationmaps/FixLocationMapsPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/fixlocationmaps/FixLocationMapsPatch.kt
@@ -1,0 +1,103 @@
+package app.andrewliang.patches.line.fixlocationmaps
+
+import app.andrewliang.patches.shared.Constants.COMPATIBILITY_LINE
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
+import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.patch.resourcePatch
+import app.morphe.patcher.util.smali.ExternalLabel
+import org.w3c.dom.Element
+import org.w3c.dom.Node
+
+/** MicroG-RE's package. Its namespace stays `com.google.android.gms`. */
+private const val MICROG_PACKAGE = "app.revanced.android.gms"
+
+private const val EXTENSION_CLASS = "Lapp/andrewliang/extension/LocationMaps;"
+
+/**
+ * Manifest half: package visibility for MicroG-RE.
+ *
+ * LINE is `targetSdk 30+`, so without this `createPackageContext` cannot even see MicroG-RE and
+ * fails as "package not found". Nameless, so it stays an internal dependency rather than a
+ * separate entry in the Manager list.
+ *
+ * "Fix chat backup sign-in via GmsCore" adds the same entry, so the check before appending is what
+ * keeps the two patches from producing a duplicate when both are enabled.
+ */
+private val fixLocationMapsManifestPatch = resourcePatch {
+    execute {
+        document("AndroidManifest.xml").use { document ->
+            val manifest = document.getElementsByTagName("manifest").item(0)
+
+            fun Node.hasChild(tag: String, name: String) =
+                (0 until childNodes.length)
+                    .map { childNodes.item(it) }
+                    .any { it is Element && it.tagName == tag && it.getAttribute("android:name") == name }
+
+            val queries = (0 until manifest.childNodes.length)
+                .map { manifest.childNodes.item(it) }
+                .firstOrNull { it is Element && it.tagName == "queries" }
+                ?: manifest.appendChild(document.createElement("queries"))
+
+            if (!queries.hasChild("package", MICROG_PACKAGE)) {
+                queries.appendChild(
+                    document.createElement("package").apply {
+                        setAttribute("android:name", MICROG_PACKAGE)
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Suppress("unused")
+val fixLocationMapsPatch = bytecodePatch(
+    name = "Fix location maps via GmsCore",
+    description = "Shows a map again on the location screens of a re-signed build. This covers " +
+        "the location picker, the location messages in a chat, and the location posts. The tiles " +
+        "come from OpenFreeMap and do not look like Google Maps. This patch needs MicroG-RE " +
+        "7.0.0 or later. A Root Mount install does not need this patch.",
+    default = true,
+) {
+    compatibleWith(COMPATIBILITY_LINE)
+
+    dependsOn(fixLocationMapsManifestPatch)
+
+    extendWith("extensions/extension.mpe")
+
+    // Google decides whether a map may draw from the API key plus the app's signing certificate.
+    // The renderer reports both from a Play Services process, not from LINE, so no patch can
+    // correct the certificate — see the extension for the full path. What a patch CAN do is hand
+    // LINE a different renderer.
+    //
+    // `fo/p.b` is where LINE resolves the context it loads the renderer from, and all three of its
+    // callers are in `fo/p`, so this one injection covers every map surface in the app.
+    //
+    // Only this method moves. `DynamiteModule` holds its own "com.google.android.gms" literal, and
+    // rewriting that would send ads, vision, ML Kit and TFLite to MicroG-RE as well — the same trap
+    // "Fix chat backup sign-in via GmsCore" avoids by overriding one client instead of the shared
+    // base class.
+    execute {
+        val method = MapsModuleContextFingerprint.method
+
+        // The extension returns null when MicroG-RE is missing, or too old to carry a renderer,
+        // and the branch then falls into the original body, which keeps talking to Play Services.
+        // So the patch changes nothing on a device that cannot serve the map.
+        //
+        // v0 is safe to use: the method declares it, and its own first instruction overwrites it
+        // (`sget-object v0, Lfo/p;->a`), so nothing downstream reads what this leaves behind.
+        // The label binds to a real instruction. A label written inside an injected block is
+        // resolved against the block's own addresses and would branch into the middle of an
+        // earlier instruction.
+        method.addInstructionsWithLabels(
+            0,
+            """
+                invoke-static { p0 }, $EXTENSION_CLASS->getMapsContext(Landroid/content/Context;)Landroid/content/Context;
+                move-result-object v0
+                if-eqz v0, :original
+                return-object v0
+            """,
+            ExternalLabel("original", method.getInstruction(0)),
+        )
+    }
+}


### PR DESCRIPTION
Closes #92.

## The bug

On a re-signed build (Standard install), every map in LINE draws as an empty grid. LINE still finds
the current location, and you can still send it. Only the map is blank. You also cannot move the map
to pick a different point. A Root Mount install keeps the original signature of LINE, and it does not
show this problem.

The problem covers eight layouts, not one. This is why the report says "or sent to chat": the message
bubble also looks broken.

| Layout | Surface |
|---|---|
| `select_location_activity.xml` | the location picker |
| `location_viewer.xml` | full-screen viewer for a received location |
| `chat_ui_row_send_msg_location.xml` | outgoing location bubble in a chat |
| `chat_ui_row_receive_msg_location.xml` | incoming location bubble in a chat |
| `note_post_media_location.xml`, `note_home_write_location_media_layout.xml` | Notes location posts |
| `post_media_location.xml`, `timeline_write_location_media_layout.xml` | Timeline/VOOM location posts |

## Why no patch can correct the certificate

This is the third break that comes from re-signing. It is the only one where the certificate cannot
be corrected.

| | Push notifications | Google sign-in | **Location maps** |
|---|---|---|---|
| Who reports the certificate | **LINE's own** bundled FIS code | Play Services | **Play Services** |
| Error | `FisError: BAD CONFIG` | `UNREGISTERED_ON_API_CONSOLE` | `Authorization failure` |
| Fix | rewrite the header | none | redirect the renderer |

LINE ships only the thin client of the Maps SDK v2. `fo/p.b` loads the renderer out of Play Services
with `DynamiteModule`. The renderer then binds `ApiTokenService` in the Play Services process. That
process reads the real signing certificate and asks the Google server for a tile token. No code in
LINE's dex reports this certificate. `fixpushnotifications` is the opposite case, because LINE's own
code builds the `X-Android-Cert` header.

Send-current-location still works because the fix comes from the framework `LocationManager`, not
from Play Services. LINE bundles no `FusedLocationProviderClient`.

## The fix

MicroG-RE added a Maps renderer for this redirect (PR #187). PR #219 then put all three renderers in
one APK and added keyless OpenFreeMap tiles. The renderer validates neither the key nor the
signature.

`fo/p.b` is the one choke point, because all three of its callers are inside `fo/p`. Four
instructions at the start of this method cover all eight surfaces:

```smali
invoke-static { p0 }, Lapp/andrewliang/extension/LocationMaps;->getMapsContext(Landroid/content/Context;)Landroid/content/Context;
move-result-object v0
if-eqz v0, :original     # ExternalLabel bound to the original first instruction
return-object v0
```

Three points to review:

- **`v0` is free at index 0.** The method is `.locals 1`, and its first instruction is `sget-object v0, Lfo/p;->a`. Nothing reads what the injection leaves in `v0`.
- **The extension caches the miss as well as the hit.** LINE caches the context in the static `Lfo/p;->a`, and the early return skips that store. The injection also runs before LINE's own cache check, so a remembered miss stops every call from repeating a failing `createPackageContext`.
- **`DynamiteModule` stays untouched.** Its own `"com.google.android.gms"` literal is shared with ads, vision, ML Kit and TFLite. A rewrite there sends all of them to MicroG-RE. This is the same trap as `kl.d.E()`: redirect the one call site, not the shared resolver.

The extension returns `null` when MicroG-RE is absent, or too old to carry a renderer. The branch
then falls into the original body, so the patch does nothing and causes no new failure.

`default = true`. The patch only acts when MicroG-RE 7.0.0 or later is installed, so most users get
either a working map or no change. One group loses something: a Root Mount user who installed
MicroG-RE for chat backup already has working Google tiles, and this patch replaces them with
OpenFreeMap ones. That user must turn the patch off.

## Two requirements, both found in review

**MicroG-RE 7.0.0 or later.** The renderer landed in 7.0.0 (2026-09-01). An older build has the
package and no `CreatorImpl`. Then `createPackageContext` succeeds, `fo/p.c` fails its `loadClass`,
takes `:catch_2`, and returns the `const/4 v0, 0x0` it set at the top. `fo/p.a` then calls
`invoke-interface {v1}, Lfo/r;->d()I` inside a try that catches only `RemoteException`, so the null
renderer is an uncaught NPE. That would turn a blank map into a crash, and it is not a remote case:
*Fix chat backup sign-in via GmsCore* documents MicroG-RE **6.1.4**, which is months older than the
renderer. The extension therefore loads `CreatorImpl` itself before it returns the context, and
returns `null` when the class is absent.

**Real Play Services must also be installed.** `fo/p.b` is not the first gate. `fo/p.a` runs
`am/j.e(Context, 0xcc77c0)` first and throws `am.g` before `b` is reached. `am/j.e` looks for the
literal package `com.google.android.gms`, which MicroG-RE does not claim. On a de-Googled device
with only MicroG-RE, the patch does nothing and the map stays blank.

One LINE fallback is neutered, and this is accepted. `fo/p.a`'s `:catch_1` handles
`UnsatisfiedLinkError` by resetting `Lfo/p;->a` and retrying with the legacy renderer. The patched
`b` ignores `p1` and returns the extension's own cache, so that retry gets the same MicroG
renderer.

## Verification

The verification is static. The patch is not yet tested on a device.

- The fingerprint resolves against 26.14.0 (`Applied: Fix location maps via GmsCore`).
- The `if-eqz` instruction targets the original first instruction, and the original body does not change.
- Both `.catch` ranges rebase correctly. `registers=3`, so the register count does not grow.
- `invoke-static {v1}` passes `p0`, and the result goes into `v0`.
- An offset sweep is clean over 648,591 methods in 14 dex files.
- The extension loads `CreatorImpl` before it stores the context. The bytecode order is `createPackageContext`, then `loadClass`, then the cache store.
- The fingerprint still resolves with the first parameter pinned.
- All 25 default patches apply together, this one included.
- The manifest reuses the existing `<queries>` block of LINE and adds `app.revanced.android.gms` one time. When *Fix chat backup sign-in via GmsCore* is also enabled, the count stays at one entry.

Do these checks on a device with MicroG-RE 7.1.0:

1. Open all four visible surfaces. Each surface must draw tiles.
2. Move the map in the picker. Put the pin on a different point.
3. Read `logcat -s "Google Android Maps SDK"`. The line `Ensure that the following Android Key exists` must not appear.
4. Read `logcat -s AndrewLineMaps`. The line "Loading maps from MicroG-RE." must appear.
5. Do a test of the QR and barcode scanner. This check proves that ML Kit stays on real Play Services.
6. Remove MicroG-RE. The build must then behave like an unpatched one.
7. Install MicroG-RE 6.1.4, which has no renderer. The map must stay blank, and LINE must not crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
