### PR TITLE
feat!: group patch names by category, and rename the MicroG-RE patches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ From decompiling LINE 26.14.0 (detail in `work/decompiled-line-<ver>/NOTES-integ
 
 **Implication:** messaging patches are safe on a re-signed build. Defeating LINE Pay would mean neutralizing the VKey native library (out of scope). Anchor fingerprints on **string literals / non-obfuscated class names** — LINE obfuscates class and method names *including* `org.apache.thrift`'s, so a seemingly-stable framework type is not a safe anchor.
 
-### Re-signed builds & closed-app push notifications (fixed by "Fix push notifications")
+### Re-signed builds & closed-app push notifications (fixed by "[Fix] Restore push notifications")
 
 Re-signing (Standard install) breaks push while the app is *fully closed*. Unlike the Google sign-in limitation below, this **is** fixable in-APK — `patches/line/fixpushnotifications/`, device-confirmed on a re-signed LINE 26.11.0, descriptors re-anchored for 26.14.0.
 
@@ -97,7 +97,7 @@ Re-signing (Standard install) breaks push while the app is *fully closed*. Unlik
 - **Which cert:** `base.apk` uses APK Signature Scheme **v3.1 key rotation** (two certs) and `GET_SIGNATURES` returns the lineage-**root** one, so the patch injects the SDK 24–32 signer `89396DC419292473972813922867E6973D6F5C50`. Fallback if `BAD CONFIG` persists: the rotated SDK 33+ signer `6A2927D945AEA6571E1DA5566802F25045D367BD`. Re-derive both with `apksigner verify --print-certs base.apk` on a version bump — 26.14.0 carries the same v3.1 lineage, so both hashes are unchanged and this patch needed no edit.
 - **Verify:** disassemble `ct/c` — `const-string v$reg, "<sha1>"` must land in the `addRequestProperty` value register (`registerE`) right before the `X-Android-Cert` send. On device, `PersistedInstallation*.json` `Status` should flip `4 → 3` (REGISTERED). **The on-device flip is the real proof;** disassembly only shows the header was rewritten.
 
-### Re-signed builds & empty location maps (fixed by "Fix location maps via GmsCore")
+### Re-signed builds & empty location maps (fixed by "[Fix] Restore location maps via MicroG-RE")
 
 Third member of the re-signing family, and the one where **no certificate fix exists**. Full detail
 in `docs/line-patch-map.md` ("Location maps") — read it before touching this.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Google Play Services. No patch can change this ([details](docs/line-patch-map.md
 **Workaround:** install with **Root Mount**, which keeps LINE's original signature. Do not use the
 **Standard** install.
 
-This limitation does not affect chat-history backup. The *Fix chat backup sign-in via GmsCore*
+This limitation does not affect chat-history backup. The *[Fix] Restore chat backup sign-in via MicroG-RE*
 patch restores it through [MicroG-RE](https://github.com/MorpheApp/MicroG-RE).
 
 ### LINE: maps show an empty grid (re-signed builds)
@@ -98,7 +98,7 @@ its original signing certificate. A re-signed build changes that certificate. Go
 reports the certificate from its own process, so no patch can correct it
 ([details](docs/line-patch-map.md)).
 
-**Workaround:** enable the *Fix location maps via GmsCore* patch. It draws the maps through
+**Workaround:** enable the *[Fix] Restore location maps via MicroG-RE* patch. It draws the maps through
 [MicroG-RE](https://github.com/MorpheApp/MicroG-RE) **7.0.0 or later** instead, which is the first
 version with a map renderer. Google Play Services must still be installed. The tiles then come from OpenFreeMap,
 so they do not look like Google Maps. There is no satellite view. A **Root Mount** install keeps

--- a/docs/line-patch-map.md
+++ b/docs/line-patch-map.md
@@ -89,7 +89,7 @@ whatever class owns that `f()`.
 | LINE GIFT (`chathistory_attach_dialog_label_giftshop`) | `yi1.h` | `GIFT` | `contains(ds3.a.GIFT)` |
 | Files `yi1.g`, Contact `yi1.f`, Location `yi1.m`, Voice `yi1.t`, Keep `yi1.i`, PayPay `yi1.p`, Live talk `yi1.l`, LINE MUSIC `yi1.n` | — | (their own) | — |
 
-**To hide one static tile** (used by "Hide Transfer button", "Hide LINE GIFT button" and the Calendar
+**To hide one static tile** (used by "[Chat] Hide Transfer button", "[Chat] Hide LINE GIFT button" and the Calendar
 `+` tile): anchor its ctor on the **unique read of its `wi1.b$b` type constant** — each constant is read
 in that one ctor only, and pinning the ctor's parameter list excludes the enum's `<clinit>` `sput` —
 then `mutableClassDefBy(fp.method.definingClass)`, select `j(Lxk1/b;)Z` by descriptor, and prepend
@@ -105,7 +105,7 @@ icons and destinations all come from the server payload, **not** from local reso
 
 - **Hide the whole category (stable):** every service is an `yi1.d`, built *only* in `xi1.c`, so forcing
   **`yi1.d.f(Lxk1/b;Lwi1/b;Lyi1/a$a;)Z`** to `return false` drops them all at once with no dependency on
-  the drifting server payload. This is **"Hide attach menu extra tools"**. Anchor: `yi1.d.f` is the only
+  the drifting server payload. This is **"[Chat] Hide attach menu extra tools"**. Anchor: `yi1.d.f` is the only
   `f(...)Z` reading `Lk81/a;->f` (its `availableChatTypes` set), which separates it from the sibling
   `f()` overrides in `yi1.a`/`yi1.p`.
 - **Hide one service (fragile — avoid):** a single service is identifiable only by its LINE service
@@ -120,7 +120,7 @@ icons and destinations all come from the server payload, **not** from local reso
 Easy to conflate. They are separate features with separate entry points, gates, and destinations.
 
 **Calendar** (native LINE Calendar; strings `line_calendar_*`; feature gate interface `or0.d`, impl
-`wr0.j`). Five in-messenger entry points, all removed by **"Hide calendar buttons"**:
+`wr0.j`). Five in-messenger entry points, all removed by **"[Chat] Hide calendar buttons"**:
 
 | Surface | Class / anchor | Hide technique |
 |---|---|---|
@@ -134,7 +134,7 @@ Easy to conflate. They are separate features with separate entry points, gates, 
 `z00.n` row built in `ChatHistoryMenuFragment` (~the `z00.n.<init>` block using string `0x7f150e87`
 + icon `0x7f0807ce`), gated by the boolean field `Lv00/o4;->l:Z` (the sole UI read of that field).
 Opens a **server-configured web page** (`settings.e$c.D`), not the native calendar. Removed by
-**"Hide Events button"** — because `z00.n` is shared by other rows, patch at the build site: replace
+**"[Chat] Hide Events button"** — because `z00.n` is shared by other rows, patch at the build site: replace
 the `iget-boolean … s4.l` (matched by `fieldAccess(Lv00/o4;,"l")` + `literal(0x7f150e87)`) with a
 `const 0` into the same register.
 
@@ -148,8 +148,8 @@ The header button row (Chats tab, `com.linecorp.line.chattab.header.ChatTabHeade
 `qz1.f`) is built from the Kotlin enum **`q11.q`** (constants `AI_FRIEND, ALBUM, CALENDAR, OPEN_CHAT,
 PLUS_MENU` — names survive obfuscation). Buttons are `sget-object <q11.q const>` + `add(...)` into a
 `ListBuilder` `ki8.b`. A separate green-dot icon `Set` uses `ki8.j` and does **not** include
-`CALENDAR`. To hide a header button, remove its `sget`+`add` pair (see "Hide calendar buttons" header
-row, and the sibling "Hide community button" which targets `OPEN_CHAT`).
+`CALENDAR`. To hide a header button, remove its `sget`+`add` pair (see "[Chat] Hide calendar buttons" header
+row, and the sibling "[Chat] Hide community button" which targets `OPEN_CHAT`).
 
 ---
 
@@ -164,13 +164,13 @@ enum is **not obfuscated**, so fingerprint on `returnType = "Ljava/util/List;"` 
 |---|---|---|---|---|
 | `HOME` / `HOME26` / `GLOBALHOME` | `hometab` / `linehome` / `globalhome` | — | always (one of the three) | — |
 | `CHAT` | `chatlist` | — | always | — |
-| `COMMERCE` | `commercetab` | `gnb_commerce` — "Shopping" / ja **ショッピング** | `function.maintab.commercetab` (JP) | **Hide Shopping tab** |
-| `COMMERCE_TW` | `commercetwtab` | `tw_commerce_tab_gnb` — "Discover" / zh-TW **逛逛** | `function.maintab.commercetwtab` (TW) | **Hide Shopping tab** |
+| `COMMERCE` | `commercetab` | `gnb_commerce` — "Shopping" / ja **ショッピング** | `function.maintab.commercetab` (JP) | **[Tab] Hide Shopping tab** |
+| `COMMERCE_TW` | `commercetwtab` | `tw_commerce_tab_gnb` — "Discover" / zh-TW **逛逛** | `function.maintab.commercetwtab` (TW) | **[Tab] Hide Shopping tab** |
 | `SQUARE` | `squaretab` | — | `rm5.b.C()` | — |
-| `TIMELINE` | `timeline` | — | `db0.k0.a(m2)` | Hide VOOM tab |
-| `NEWS` / `NEWS_ROW` | `newstab` / `newsrowtab` | — | `s28.a.b()` / `kc3.d.a()` | Hide LINE TODAY tab |
+| `TIMELINE` | `timeline` | — | `db0.k0.a(m2)` | [Tab] Hide VOOM tab |
+| `NEWS` / `NEWS_ROW` | `newstab` / `newsrowtab` | — | `s28.a.b()` / `kc3.d.a()` | [Tab] Hide LINE TODAY tab |
 | `CALL` | `call` | — | `y28.d.c()` | — |
-| `MINI` / `WALLET` | `minitab` / `wallettab` | — | `m2.a().Y().d()` / `m2.a().H0().l()` | Hide Wallet tab |
+| `MINI` / `WALLET` | `minitab` / `wallettab` | — | `m2.a().Y().d()` / `m2.a().H0().l()` | [Tab] Hide Wallet tab |
 
 **`COMMERCE`, `COMMERCE_TW`, `SQUARE` and `TIMELINE` share one `if`/`else-if` chain**, competing for a
 single slot. Two rules follow:
@@ -181,7 +181,7 @@ single slot. Two rules follow:
   the branch's trailing `goto`, so the slot stays empty, as stock LINE does when the gate is on.
 - **Anchor each patch on its own constants only.** The tab patches run in arbitrary order against one
   method and each fingerprint resolves *after* earlier mutations, so anchoring on a constant another
-  patch removes breaks the match. (Thus Hide Shopping tab avoids `TIMELINE` and `MINI`/`WALLET`; see
+  patch removes breaks the match. (Thus [Tab] Hide Shopping tab avoids `TIMELINE` and `MINI`/`WALLET`; see
   also `hidevoomtab/Fingerprints.kt`.)
 
 **A missing tab is safe everywhere.** Tab→index lookups are `Math.max(list.indexOf(...), 0)`, clamping
@@ -205,8 +205,8 @@ screenshot. That is the only step separating "the instructions are gone" from "t
 
 The Home tab renders a single server-driven `List<y82.j0>`. Everything on the tab is one of these
 modules — the friends list, the service icons, the ads, and the whole content feed below the friends
-list. Three patches filter that list: *Hide Home modules*, *Hide Home content feed*, and
-*Disable LINE Premium*. If you change this surface, update all three call sites.
+list. Three patches filter that list: *[Home] Hide Home modules*, *[Home] Hide Home content feed*, and
+*[Premium] Disable LINE Premium*. If you change this surface, update all three call sites.
 
 **The chain.** `v52.g.a(Ls52/i;Ly82/y0;)` assembles the list from the GCS response (one giant
 `packed-switch` over the payload oneof; **jadx fails on this method** — `Method not decompiled` — so
@@ -243,7 +243,7 @@ identifiers and all survive verbatim — the patches match on those, never on th
 **Three types are new since 26.11.0** (45 → 48) and are *not* in any blocklist yet:
 `GlobalHomeRecommendedSticker`, `GlobalHomeLoungeHoroscope` and
 `GcsGlobalHomeActivityHybridContentCard` (top-level `y82.n0`). Nothing was removed. The first two
-look like **Hide Home modules** candidates if they render in any region — that needs a full
+look like **[Home] Hide Home modules** candidates if they render in any region — that needs a full
 hidden-vs-kept inventory and its own device pass before the blocklist widens.
 
 Regenerate this diff on a bump by extracting the `const-string` from every `getType()` in the
@@ -251,15 +251,15 @@ classes referencing `Ly82/k0;` and comparing old tree to new.
 
 | `getType()` | Class | Surface | Status |
 |---|---|---|---|
-| `HomeContentsRecommendation` | `a0$s` | recommended stickers / content | **Hide Home modules** (device-confirmed) |
-| `HomePerformanceAd` | `a0$j0` | performance ads in the feed | **Hide Home modules** (device-confirmed) |
-| `FLEX` | `a0$f` | 即時夯話題 hot topics **and** the bottom promo/ad block | **Hide Home modules** (device-confirmed) |
-| `AdModel` | `a0$a` | generic ad module (`GcsAdModuleViewData` / `GcsAdMeta`) | **Hide Home modules** (static evidence only — never seen on device) |
-| `HomeFeedPost` | `a0$z` | OA / LINE NEWS post card | **Hide Home content feed** |
-| `HomeFeedLiveSingle` | `a0$w` | the `OA_LIVE` variant | **Hide Home content feed** |
-| `HomeFeedMatomeSingle` / `-Carousel` | `a0$y` / `a0$x` | AI-digest ("matome") news cards | **Hide Home content feed** |
-| `HomeFeedUnitBigVisual` / `-Grid` / `-Ranking` / `-ShortFormGrid` / `-Single` / `-SingleAndGrid` | `a0$b0`–`a0$g0` | content-unit layouts, each wrapping posts | **Hide Home content feed** |
-| `HomeFeedDefaultPageError` / `-DefaultPageLoading` / `HomeFeedError` / `HomeFeedSeedPostError` | `a0$t` / `a0$u` / `a0$v` / `a0$a0` | that feed's error & spinner placeholders | **Hide Home content feed** |
+| `HomeContentsRecommendation` | `a0$s` | recommended stickers / content | **[Home] Hide Home modules** (device-confirmed) |
+| `HomePerformanceAd` | `a0$j0` | performance ads in the feed | **[Home] Hide Home modules** (device-confirmed) |
+| `FLEX` | `a0$f` | 即時夯話題 hot topics **and** the bottom promo/ad block | **[Home] Hide Home modules** (device-confirmed) |
+| `AdModel` | `a0$a` | generic ad module (`GcsAdModuleViewData` / `GcsAdMeta`) | **[Home] Hide Home modules** (static evidence only — never seen on device) |
+| `HomeFeedPost` | `a0$z` | OA / LINE NEWS post card | **[Home] Hide Home content feed** |
+| `HomeFeedLiveSingle` | `a0$w` | the `OA_LIVE` variant | **[Home] Hide Home content feed** |
+| `HomeFeedMatomeSingle` / `-Carousel` | `a0$y` / `a0$x` | AI-digest ("matome") news cards | **[Home] Hide Home content feed** |
+| `HomeFeedUnitBigVisual` / `-Grid` / `-Ranking` / `-ShortFormGrid` / `-Single` / `-SingleAndGrid` | `a0$b0`–`a0$g0` | content-unit layouts, each wrapping posts | **[Home] Hide Home content feed** |
+| `HomeFeedDefaultPageError` / `-DefaultPageLoading` / `HomeFeedError` / `HomeFeedSeedPostError` | `a0$t` / `a0$u` / `a0$v` / `a0$a0` | that feed's error & spinner placeholders | **[Home] Hide Home content feed** |
 | `FriendsSubTabFriendsList`, `-AllAlbum`, `-Calendar`, `-LatestNotifications`, `-RecentlyUpdatedProfiles` | `a0$i`, `a0$g`, `a0$h`, `a0$j`, `a0$k` | the friends list and its sub-tabs | kept |
 | `HomeSocialGraph`, `HomeRecentlyProfileUpdate`, `HomeActivityFriendList`, `GlobalHomeFriendList` | `a0$m0`, `a0$k0`, `a0$r`, `a0$o` | friend updates / profiles | kept |
 | `HomeServiceList`, `GlobalHomeServiceSection`, `SquareJoinedChatList`, `HomeNotificationHub` | `a0$l0`, `a0$p`, `a0$q0`, `a0$i0` | service icons, OpenChat list, notification hub | kept |
@@ -268,7 +268,7 @@ classes referencing `Ly82/k0;` and comparing old tree to new.
 | `CommerceTwTabFriendshipGifts`, `-GreetingBanners`, `-QuickPolls`, `-Shortcuts` | `a0$b`–`a0$e` | the TW commerce tab | kept |
 | `HomeActivityCard` | `a0$q` | recommendation surface (`contentList` / `extraContentList`) | **not blocked** — no device evidence |
 | `GcsHomeActivityHybridContentCard` | `y82.o0` (top-level) | the hybrid variant of the above | **not blocked** — no device evidence |
-| `HomeTabLypRecommendation` | `a0$n0` | LYP premium upsell | **Disable LINE Premium** (third lever, no device evidence — see `line-premium-map.md`) |
+| `HomeTabLypRecommendation` | `a0$n0` | LYP premium upsell | **[Premium] Disable LINE Premium** (third lever, no device evidence — see `line-premium-map.md`) |
 | `GcsDummyHybridModule` | `y82.m0` (top-level) | dev/dummy, no renderer | kept |
 
 **Take this table from jadx, never from a smali grep.** 17 of the 43 nested classes are Kotlin
@@ -431,7 +431,7 @@ some of them:
 |---|---|---|
 | Home tab Google banner | `function.hometab.ad_rc.*`, `function.hometab.ads.displayrate*` | Google view, covered |
 | Chats tab Google banner | `function.chattab.ad_rc.*` | Google view, covered |
-| Smart Channel | `function.chattab.smartch.*` | `Hide ad views` and `Remove banner ads` |
+| Smart Channel | `function.chattab.smartch.*` | `[Ad] Hide ad views` and `[Ad] Remove banner ads` |
 | Album ads | `function.album.ad.*`, `function.moa.album.ad.*` | LAD inventory, covered |
 | Note ads | `function.note.ad.{list,end}_inventory_key` | LAD inventory, covered |
 | OpenChat header ads (4 places) | `function.square.{chatroom,note,thread_space,your_threads}.header_ad.*` | LAD or Google, covered |
@@ -487,21 +487,21 @@ starting point, so no one needs to sweep the APK again.
 
 | Patch (name) | Package | Targets |
 |---|---|---|
-| Hide calendar buttons | `line.hidecalendar` | the 5 Calendar surfaces above |
-| Hide Events button | `line.hideevents` | the `z00.n` Events chat-menu row |
-| Hide Transfer button | `line.hidetransfer` | `yi1.j` (`+` Transfer/LINE Pay tile) |
-| Hide LINE GIFT button | `line.hidegift` | `yi1.h` (`+` LINE GIFT tile) |
-| Hide attach menu extra tools | `line.hideattachmenutools` | all server-driven `yi1.d` services |
-| Redirect LINE Pay | `line.disablepay` | `PayLaunchActivity` / `PayLiffActivity` onCreate (see below) |
-| Keep unsent messages | `line.keepunsent` | `la8.x.invoke` — the unsend DB write (see below) |
-| Hide Shopping tab | `line.hideshoppingtab` | `COMMERCE` + `COMMERCE_TW` in `wy7.b.a()` (see above) |
-| Fix location maps via GmsCore | `line.fixlocationmaps` | `fo/p.b` — the maps module context (see below) |
+| [Chat] Hide calendar buttons | `line.hidecalendar` | the 5 Calendar surfaces above |
+| [Chat] Hide Events button | `line.hideevents` | the `z00.n` Events chat-menu row |
+| [Chat] Hide Transfer button | `line.hidetransfer` | `yi1.j` (`+` Transfer/LINE Pay tile) |
+| [Chat] Hide LINE GIFT button | `line.hidegift` | `yi1.h` (`+` LINE GIFT tile) |
+| [Chat] Hide attach menu extra tools | `line.hideattachmenutools` | all server-driven `yi1.d` services |
+| [General] Redirect LINE Pay | `line.disablepay` | `PayLaunchActivity` / `PayLiffActivity` onCreate (see below) |
+| [Chat] Keep unsent messages | `line.keepunsent` | `la8.x.invoke` — the unsend DB write (see below) |
+| [Tab] Hide Shopping tab | `line.hideshoppingtab` | `COMMERCE` + `COMMERCE_TW` in `wy7.b.a()` (see above) |
+| [Fix] Restore location maps via MicroG-RE | `line.fixlocationmaps` | `fo/p.b` — the maps module context (see below) |
 
 Each is an independent, `default = true`, user-facing `bytecodePatch` — one feature (or one
 feature's full set of entry points) per patch. Most are instruction-level edits. *Redirect LINE
-Pay*, *Keep unsent messages* and *Fix location maps* carry extension code.
+Pay*, *[Chat] Keep unsent messages* and *[Fix] Restore location maps* carry extension code.
 
-## LINE Pay intake & the "Redirect LINE Pay" patch
+## LINE Pay intake & the "[General] Redirect LINE Pay" patch
 
 **Why redirect instead of disable:** the messenger cannot run its own Pay flow on a re-signed build
 (the bundled VKey/V-Guard check fails — see `CLAUDE.md`). The patch (still packaged
@@ -565,7 +565,7 @@ hardcode `sv3.n`, which drifts).
 
 ---
 
-## Message unsend (receive side) & the "Keep unsent messages" patch
+## Message unsend (receive side) & the "[Chat] Keep unsent messages" patch
 
 ### How an incoming unsend reaches the database
 
@@ -629,7 +629,7 @@ stores the row already stripped — nothing local to keep.
 | cursor → content model | `Lma8/t;->e(Lcb8/q7;Ljp/naver/line/android/util/j;Lz58/b;)Lna8/g;` — `UNSENT` builds `Lna8/g$s$h0;` from `from_mid` |
 | content → UI model | `Lm11/b;->k(Lna8/g$s;)Ll11/h;` → `Ll11/h$h0;` |
 | UI model → text | `Lcl1/c;->a(Landroid/content/Context;Ll11/h;Lo21/a;)Ljava/lang/CharSequence;` |
-| bubble decoration | `Lnl1/b5;->K0(...)` — appends the "How to unsend discreetly" link on *your own* unsends (suppressed by *Hide premium unsend upsells*) |
+| bubble decoration | `Lnl1/b5;->K0(...)` — appends the "How to unsend discreetly" link on *your own* unsends (suppressed by *[Premium] Hide premium unsend upsells*) |
 
 Strings: `chathistory_message_format_unsent_receiver` (`0x7f150d65`, "%1$s unsent a message.") and
 `chathistory_message_format_unsent_sender` (`0x7f150d66`, "You unsent a message.") — chosen by
@@ -1121,7 +1121,7 @@ hard-requires do **not** resolve against LINE: `GooglePlayUtilityFingerprint` (n
 `"Google Play Services not available"` match is a constructor in `gl.h`). For LINE neither is
 needed anyway — real Play Services is installed, so the "GMS missing" checks never trigger.
 
-## Location maps & the "Fix location maps via GmsCore" patch
+## Location maps & the "[Fix] Restore location maps via MicroG-RE" patch
 
 Reported as issue #92 ("share location doesn't work"). On a re-signed build every map draws as an
 empty grid. The current location is still found and can still be sent, and only the map is blank.
@@ -1282,7 +1282,7 @@ later release. Nothing to patch today.
 | Feature | Strings (all dead in 26.14.0) | Why it matters when it ships |
 |---|---|---|
 | **Scroll preview** (chat list) | `chat_preview_desc_scrollpreview`, `chat_preview_banner_scrollpreview{labs,lyplite,lypstd,nonlypstd}`, `chat_chatlist_tooltip_scrollpreview{labs,lypstd,nonlypstd}` | A new chat-list feature tiered **four ways** (LINE Labs / LYP Lite / LYP Standard / non-LYP). The tier check is the thing to look at — if it is a local read of the market gate, `hidepremium` already moves it; if it is a server entitlement, it is another `INVALID_PREMIUM_STATUS` case. |
-| **LINE Calendar → standalone app cross-promo** | `line_calendar_apppromotion_link_morefeatures`, `line_calendar_apppromotion_popupdesc_eventlocation` | Would be a **6th Calendar surface** and belongs in *Hide calendar buttons*, which currently covers five. |
+| **LINE Calendar → standalone app cross-promo** | `line_calendar_apppromotion_link_morefeatures`, `line_calendar_apppromotion_popupdesc_eventlocation` | Would be a **6th Calendar surface** and belongs in *[Chat] Hide calendar buttons*, which currently covers five. |
 | **Scheduled-message upsell** | `chat_scheduledmessages_popupdesc_upgradetosendasscheduled_misc`, `chat_scheduledmessages_toast_errorwithmembership_linep` | Upsell copy for the scheduled-message feature below. |
 
 ### Live, but not yet verified against a patched build
@@ -1297,7 +1297,7 @@ returns compared with one look at a patched build.
 - `com/linecorp/line/settings/labs/view/LineUserSettingLabPremiumIntroComposeView`
 
 **Visible symptom to look for:** an LYP feature-onboarding popup appearing on a build with
-*Disable LINE Premium* applied.
+*[Premium] Disable LINE Premium* applied.
 
 For contrast, these new upsells **are** covered — each does a null-guarded facade read, so a false
 market gate takes the hide branch: `ChatVisualEndPageActivity` (photo-viewer premium banner),
@@ -1312,7 +1312,7 @@ region-dependent — check on device before widening the blocklist.
 
 | Type | Recommendation |
 |---|---|
-| `GlobalHomeRecommendedSticker` | **Candidate.** Global Home analogue of `HomeContentsRecommendation`, which *Hide Home modules* already hides — leaving this one is an inconsistency. |
+| `GlobalHomeRecommendedSticker` | **Candidate.** Global Home analogue of `HomeContentsRecommendation`, which *[Home] Hide Home modules* already hides — leaving this one is an inconsistency. |
 | `GlobalHomeLoungeHoroscope` | **Candidate.** New clutter module. |
 | `GcsGlobalHomeActivityHybridContentCard` | **Keep.** Analogue of `GcsHomeActivityHybridContentCard`, which is deliberately kept. |
 
@@ -1327,11 +1327,11 @@ assuming:
   (`zzbyb` → `zzbym`, a new `com/google/android/gms/ads/…/hsdp` deep-link wrapper).
 - **Nullable premium badge (`Lq83/n;`):** all 63 field reads are null-guarded. The 32 that look
   unguarded are inside `q83/n`'s own `equals`/`hashCode`/`toString`, where the holder is `this`.
-  So *Disable LINE Premium* adds no new `getDrawable(0)`-class crash risk beyond the known
+  So *[Premium] Disable LINE Premium* adds no new `getDrawable(0)`-class crash risk beyond the known
   Settings ▸ Chats one, which the backup-gate lever covers.
 - **Read receipts:** `DisabledManualReadReceiptViewModel` is new and sounds relevant, but it is a
   40-line Square (OpenChat) component-graph stub that never touches `TalkServiceClient` or the
-  `na3.e` read manager. *Keep chats unread* is unaffected.
+  `na3.e` read manager. *[Chat] Keep chats unread* is unaffected.
 
 ---
 

--- a/docs/line-premium-map.md
+++ b/docs/line-premium-map.md
@@ -127,9 +127,9 @@ So the practical direction is **hiding** premium, not unlocking it.
 
 ---
 
-## Disabling premium (this bundle: `Disable LINE Premium`)
+## Disabling premium (this bundle: `[Premium] Disable LINE Premium`)
 
-Because premium cannot be unlocked, `Disable LINE Premium` **hides every premium surface** — upsell
+Because premium cannot be unlocked, `[Premium] Disable LINE Premium` **hides every premium surface** — upsell
 popups/banners, badges/locks, the "LINE Premium" settings page and its entry rows, the subscribe/manage
 flows — by forcing LINE's own market-availability flag off.
 
@@ -185,7 +185,7 @@ LINE version.
 
 **Symptom:** on a patched build, **Settings ▸ Chats** threw and bounced back to Home. Stock is fine;
 reproduced on both Standard (re-signed) and Root Mount, that is signing-independent. Caused by
-`Disable LINE Premium` alone.
+`[Premium] Disable LINE Premium` alone.
 
 **Chain** (all verified against decompiled 26.14.0):
 
@@ -267,8 +267,8 @@ The filter goes on `lb2.g$a.<init>(List, Z×5, String, Long, Long, I, Z)`, at in
 - **One literal comparison needs no extension.** The type string is compared in smali, with the
   literal as the receiver of `String.equals`, so a null type is safe. This patch stays free of
   extension code.
-- **Three patches prepend at that same index** — this one, `Hide Home modules` and
-  `Hide Home content feed`. All three are pure `List -> List` filters on `p1`, so the patch that
+- **Three patches prepend at that same index** — this one, `[Home] Hide Home modules` and
+  `[Home] Hide Home content feed`. All three are pure `List -> List` filters on `p1`, so the patch that
   applies last runs first and the result is the same in any order. Verified in the dex: the three
   `invoke-static` + `move-result-object v1` pairs chain, then the original `Object.<init>` and
   `iput-object v1` into field `a`.
@@ -279,7 +279,7 @@ The full Home module inventory (45 types) is in `line-patch-map.md`, section "Ho
 module capture from a Taiwan account (8 modules, no `HomeTabLypRecommendation`). The module list is
 region-driven and server-driven, so this needs a tester whose account gets the upsell.
 
-### Known survivors: premium unsend upsells (patch `Hide premium unsend upsells`)
+### Known survivors: premium unsend upsells (patch `[Premium] Hide premium unsend upsells`)
 
 Two premium-unsend surfaces read config directly, bypassing `a83.a.d()`, so the master lever does not
 hide them — a supplementary patch does:

--- a/extensions/extension/src/main/java/app/andrewliang/extension/HomeFeed.java
+++ b/extensions/extension/src/main/java/app/andrewliang/extension/HomeFeed.java
@@ -1,7 +1,7 @@
 package app.andrewliang.extension;
 
 /**
- * Helper for the "Hide Home content feed" LINE patch.
+ * Helper for the "[Home] Hide Home content feed" LINE patch.
  *
  * The LINE Home tab shows one server-driven list of typed modules. Each module is an m52.a0
  * with a stable getType() string. The list is the module list of the Compose state x72.h$a.

--- a/extensions/extension/src/main/java/app/andrewliang/extension/HomeModules.java
+++ b/extensions/extension/src/main/java/app/andrewliang/extension/HomeModules.java
@@ -4,7 +4,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * Helper for the "Hide Home modules" LINE patch.
+ * Helper for the "[Home] Hide Home modules" LINE patch.
  *
  * LINE's Home tab renders a server-driven list of typed modules (m52.a0, each with a stable
  * getType() string), held as the module list of the Compose state x72.h$a. The patch iterates

--- a/extensions/extension/src/main/java/app/andrewliang/extension/KeepUnsentMessages.java
+++ b/extensions/extension/src/main/java/app/andrewliang/extension/KeepUnsentMessages.java
@@ -4,7 +4,7 @@ import android.database.sqlite.SQLiteDatabase;
 import android.util.Log;
 
 /**
- * Helper for the "Keep unsent messages" patch.
+ * Helper for the "[Chat] Keep unsent messages" patch.
  *
  * <p>The patch makes LINE skip the database work it normally does when a message is unsent in a 1:1
  * or group chat, so the row survives untouched — text, media, reactions and search-index entry all

--- a/extensions/extension/src/main/java/app/andrewliang/extension/LinePayRedirect.java
+++ b/extensions/extension/src/main/java/app/andrewliang/extension/LinePayRedirect.java
@@ -8,7 +8,7 @@ import android.util.Log;
 import java.net.URLEncoder;
 
 /**
- * Helper for the "Redirect LINE Pay" patch.
+ * Helper for the "[General] Redirect LINE Pay" patch.
  *
  * LINE's messenger cannot run its own Pay flow on a re-signed/patched build (the bundled VKey
  * V-Guard integrity check fails), so instead of merely closing the Pay screen we forward the

--- a/extensions/extension/src/main/java/app/andrewliang/extension/LocationMaps.java
+++ b/extensions/extension/src/main/java/app/andrewliang/extension/LocationMaps.java
@@ -4,7 +4,7 @@ import android.content.Context;
 import android.util.Log;
 
 /**
- * Helper for the "Fix location maps via GmsCore" patch.
+ * Helper for the "[Fix] Restore location maps via MicroG-RE" patch.
  *
  * <p>LINE draws every map through the Google Maps Android SDK v2 <i>thin client</i>. The renderer
  * itself is not in LINE's APK: LINE asks {@code DynamiteModule} for
@@ -16,7 +16,7 @@ import android.util.Log;
  * LINE's API key, the token is refused, and every map renders as an empty grid.
  *
  * <p>Nothing in LINE's own bytecode reports that certificate, so it cannot be corrected the way
- * "Fix push notifications" rewrites the {@code X-Android-Cert} header. Instead this returns
+ * "[Fix] Restore push notifications" rewrites the {@code X-Android-Cert} header. Instead this returns
  * MicroG-RE's {@link Context}, whose bundled MapLibre/VTM renderer validates no key and no
  * signature. MicroG-RE added Maps support for exactly this redirect.
  *

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/chatheaderbuttons/HideCommunityButtonPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/chatheaderbuttons/HideCommunityButtonPatch.kt
@@ -6,7 +6,7 @@ import app.morphe.patcher.patch.bytecodePatch
 
 @Suppress("unused")
 val hideCommunityButtonPatch = bytecodePatch(
-    name = "Hide community button",
+    name = "[Chat] Hide community button",
     description = "Removes the community (OpenChat) button from the top of the Chats tab header.",
     default = true,
 ) {

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/disablepay/DisablePayPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/disablepay/DisablePayPatch.kt
@@ -16,7 +16,7 @@ private const val REDIRECT_AND_FINISH = """
 
 @Suppress("unused")
 val disablePayPatch = bytecodePatch(
-    name = "Redirect LINE Pay",
+    name = "[General] Redirect LINE Pay",
     description = "Opens LINE Pay flows in the standalone LINE Pay app instead of inside LINE. " +
         "The device-integrity check that fails on a re-signed build never runs. Messaging does " +
         "not change.",

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/disablevoom/DisableVoomPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/disablevoom/DisableVoomPatch.kt
@@ -6,7 +6,7 @@ import app.morphe.patcher.patch.bytecodePatch
 
 @Suppress("unused")
 val disableVoomPatch = bytecodePatch(
-    name = "Disable VOOM",
+    name = "[General] Disable VOOM",
     description = "VOOM deep links, shares, and notifications do nothing. If you open the " +
         "standalone VOOM feed, it closes. Messaging and the other tabs do not change.",
     default = true,

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/externalbrowser/ForceExternalBrowserPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/externalbrowser/ForceExternalBrowserPatch.kt
@@ -6,7 +6,7 @@ import app.morphe.patcher.patch.bytecodePatch
 
 @Suppress("unused")
 val forceExternalBrowserPatch = bytecodePatch(
-    name = "Open links in external browser",
+    name = "[General] Open links in external browser",
     description = "When you tap a web link (http or https), it opens in your default browser " +
         "instead of LINE's in-app browser. LIFF mini-apps and LINE deep links do not change.",
     default = true,

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/fixlocationmaps/FixLocationMapsPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/fixlocationmaps/FixLocationMapsPatch.kt
@@ -21,7 +21,7 @@ private const val EXTENSION_CLASS = "Lapp/andrewliang/extension/LocationMaps;"
  * fails as "package not found". Nameless, so it stays an internal dependency rather than a
  * separate entry in the Manager list.
  *
- * "Fix chat backup sign-in via GmsCore" adds the same entry, so the check before appending is what
+ * "[Fix] Restore chat backup sign-in via MicroG-RE" adds the same entry, so the check before appending is what
  * keeps the two patches from producing a duplicate when both are enabled.
  */
 private val fixLocationMapsManifestPatch = resourcePatch {
@@ -52,7 +52,7 @@ private val fixLocationMapsManifestPatch = resourcePatch {
 
 @Suppress("unused")
 val fixLocationMapsPatch = bytecodePatch(
-    name = "Fix location maps via GmsCore",
+    name = "[Fix] Restore location maps via MicroG-RE",
     description = "Shows a map again on the location screens of a re-signed build. This covers " +
         "the location picker, the location messages in a chat, and the location posts. The tiles " +
         "come from OpenFreeMap and do not look like Google Maps. This patch needs MicroG-RE " +
@@ -75,7 +75,7 @@ val fixLocationMapsPatch = bytecodePatch(
     //
     // Only this method moves. `DynamiteModule` holds its own "com.google.android.gms" literal, and
     // rewriting that would send ads, vision, ML Kit and TFLite to MicroG-RE as well — the same trap
-    // "Fix chat backup sign-in via GmsCore" avoids by overriding one client instead of the shared
+    // "[Fix] Restore chat backup sign-in via MicroG-RE" avoids by overriding one client instead of the shared
     // base class.
     execute {
         val method = MapsModuleContextFingerprint.method

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/fixpushnotifications/FixPushNotificationsPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/fixpushnotifications/FixPushNotificationsPatch.kt
@@ -24,7 +24,7 @@ private const val LINE_ORIGINAL_CERT_SHA1 = "89396DC419292473972813922867E6973D6
 
 @Suppress("unused")
 val fixPushNotificationsPatch = bytecodePatch(
-    name = "Fix push notifications",
+    name = "[Fix] Restore push notifications",
     description = "When LINE is fully closed, push notifications work again on a re-signed " +
         "build. A Root Mount install does not need this patch.",
     default = true,

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/gmscoreauth/GmsCoreAuthPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/gmscoreauth/GmsCoreAuthPatch.kt
@@ -139,11 +139,11 @@ private val gmsCoreAuthManifestPatch = resourcePatch {
  */
 @Suppress("unused")
 val gmsCoreAuthPatch = bytecodePatch(
-    name = "Fix chat backup sign-in via GmsCore",
+    name = "[Fix] Restore chat backup sign-in via MicroG-RE",
     description = "Sends the Google account picker and the Drive token of chat-history backup " +
-        "through GmsCore. Backup and restore then work on a re-signed build. This patch needs " +
-        "MicroG-RE. It does not change how you sign in to a Google account. A Root Mount install " +
-        "does not need this patch.",
+        "through MicroG-RE. Backup and restore then work on a re-signed build. It does not " +
+        "change how you sign in to a Google account. A Root Mount install does not need this " +
+        "patch.",
     default = true,
 ) {
     compatibleWith(COMPATIBILITY_LINE)

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hideadviews/HideAdViewsPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hideadviews/HideAdViewsPatch.kt
@@ -37,7 +37,7 @@ private const val HIDE_SELF_CTOR_P3 = """
 
 @Suppress("unused")
 val hideAdViewsPatch = bytecodePatch(
-    name = "Hide ad views",
+    name = "[Ad] Hide ad views",
     description = "Hides the LINE display ad views. These are the LINE Ads SDK containers in the " +
         "whole app, the chat-list Smart Channel banner, and the Google AdManager ads.",
     default = true,

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hideattachmenutools/HideAttachMenuExtraToolsPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hideattachmenutools/HideAttachMenuExtraToolsPatch.kt
@@ -6,7 +6,7 @@ import app.morphe.patcher.patch.bytecodePatch
 
 @Suppress("unused")
 val hideAttachMenuExtraToolsPatch = bytecodePatch(
-    name = "Hide attach menu extra tools",
+    name = "[Chat] Hide attach menu extra tools",
     description = "Removes all the server-provided extra tools from the + attach menu in a chat " +
         "room (Poll, Reservation, Schedule, Ladder shuffle, and more). The built-in tiles " +
         "(camera, gallery, files, and contact) do not change.",

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidecalendar/HideCalendarButtonPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidecalendar/HideCalendarButtonPatch.kt
@@ -17,7 +17,7 @@ private const val CALENDAR_MODULE_TYPE = "FriendsSubTabCalendar"
 
 @Suppress("unused")
 val hideCalendarButtonPatch = bytecodePatch(
-    name = "Hide calendar buttons",
+    name = "[Chat] Hide calendar buttons",
     description = "Removes every LINE Calendar surface inside the messenger. One is in the " +
         "Chats-tab header. Four are in a chat room: the top toolbar, the + attach menu, the " +
         "slide-out chat menu, and the message long-press menu. The last is the Calendar block " +

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hideevents/HideEventsButtonPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hideevents/HideEventsButtonPatch.kt
@@ -8,7 +8,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
 
 @Suppress("unused")
 val hideEventsButtonPatch = bytecodePatch(
-    name = "Hide Events button",
+    name = "[Chat] Hide Events button",
     description = "Removes the \"Events\" row from the slide-out menu in a chat room. Events is " +
         "a different feature from LINE Calendar, and it opens a server-hosted page.",
     default = true,

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidegift/HideGiftButtonPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidegift/HideGiftButtonPatch.kt
@@ -6,7 +6,7 @@ import app.morphe.patcher.patch.bytecodePatch
 
 @Suppress("unused")
 val hideGiftButtonPatch = bytecodePatch(
-    name = "Hide LINE GIFT button",
+    name = "[Chat] Hide LINE GIFT button",
     description = "Removes the LINE GIFT tile from the + attach menu in a chat room.",
     default = true,
 ) {

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidehomefeed/HideHomeFeedPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidehomefeed/HideHomeFeedPatch.kt
@@ -15,7 +15,7 @@ private const val FILTER_DESC = "(Ljava/util/List;)Ljava/util/List;"
 
 @Suppress("unused")
 val hideHomeFeedPatch = bytecodePatch(
-    name = "Hide Home content feed",
+    name = "[Home] Hide Home content feed",
     description = "Removes the content feed below the friends list on the Home tab. The feed " +
         "shows LINE NEWS posts, official account posts, live cards, content units, and ranking " +
         "units. The friends list, the service icons, and the other Home modules do not change.",
@@ -25,7 +25,7 @@ val hideHomeFeedPatch = bytecodePatch(
 
     extendWith("extensions/extension.mpe")
 
-    // Same mechanism as "Hide Home modules", and on the same list. The Home feed is a
+    // Same mechanism as "[Home] Hide Home modules", and on the same list. The Home feed is a
     // List<y82.j0>. Each element holds a typed y82.k0 module in field z.e. The list is the first
     // ctor argument (field `a`) of the Compose state lb2.g$a. This patch filters the list and
     // drops each module whose z.e.getType() belongs to the server content feed. Every type in
@@ -37,7 +37,7 @@ val hideHomeFeedPatch = bytecodePatch(
     // branch. The call replaces p1 (the list) with the filtered copy before the constructor
     // stores it. One constructor covers every feed build path and every state copy.
     //
-    // "Hide Home modules" prepends the same call shape at the same index. Both are pure
+    // "[Home] Hide Home modules" prepends the same call shape at the same index. Both are pure
     // List -> List filters on p1. Thus the patch that applies second runs first, and the
     // result is the same either way.
     //

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidehomemodules/HideHomeModulesPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidehomemodules/HideHomeModulesPatch.kt
@@ -15,7 +15,7 @@ private const val FILTER_DESC = "(Ljava/util/List;)Ljava/util/List;"
 
 @Suppress("unused")
 val hideHomeModulesPatch = bytecodePatch(
-    name = "Hide Home modules",
+    name = "[Home] Hide Home modules",
     description = "Hides clutter modules on the Home tab: the recommended stickers and content " +
         "section, the real-time hot-topics (即時夯話題) block, and the ad modules. A separate " +
         "patch hides the content feed below the friends list.",
@@ -34,7 +34,7 @@ val hideHomeModulesPatch = bytecodePatch(
     // a branchless call at the top of lb2.g$a.<init> to replace p1 (the list) with its
     // filtered copy before it is stored. One constructor covers every feed build path + copies.
     //
-    // "Hide Home content feed" prepends the same call shape at the same index. Both are pure
+    // "[Home] Hide Home content feed" prepends the same call shape at the same index. Both are pure
     // List -> List filters on p1. Thus the patch that applies second runs first, and the
     // result is the same either way.
     execute {

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidelinetodaytab/HideLineTodayTabPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidelinetodaytab/HideLineTodayTabPatch.kt
@@ -6,7 +6,7 @@ import app.morphe.patcher.patch.bytecodePatch
 
 @Suppress("unused")
 val hideLineTodayTabPatch = bytecodePatch(
-    name = "Hide LINE TODAY tab",
+    name = "[Tab] Hide LINE TODAY tab",
     description = "Removes the LINE TODAY (News) tab from the main bottom navigation, " +
         "in both the news-tab and news-row layouts.",
     default = true,

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidenewbadges/HideNewBadgesPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidenewbadges/HideNewBadgesPatch.kt
@@ -144,7 +144,7 @@ private fun MutableMethod.visibilityCallsOn(isBadge: (FieldReference) -> Boolean
 
 @Suppress("unused")
 val hideNewBadgesPatch = bytecodePatch(
-    name = "Hide new item badges",
+    name = "[General] Hide new item badges",
     description = "Hides the green dots and N badges that mark new items, on header buttons, " +
         "tabs, menus, lists and settings rows. Unread message counts do not change.",
     default = true,

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidepremium/HidePremiumPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidepremium/HidePremiumPatch.kt
@@ -21,7 +21,7 @@ private const val LYP_MODULE_TYPE = "HomeTabLypRecommendation"
 
 @Suppress("unused")
 val hidePremiumPatch = bytecodePatch(
-    name = "Disable LINE Premium",
+    name = "[Premium] Disable LINE Premium",
     description = "Hides all LINE Yahoo Premium (LYP) surfaces: the upsells, the badges, the " +
         "Premium settings page, and the subscribe and manage flows. Premium chat backup changes " +
         "to the ordinary chat-history backup. This patch unlocks nothing, because the server " +
@@ -124,7 +124,7 @@ val hidePremiumPatch = bytecodePatch(
         // path goes to that constructor. One literal comparison needs no extension code, so this
         // patch declares no extension.
         //
-        // "Hide Home modules" and "Hide Home content feed" prepend the same call shape at the
+        // "[Home] Hide Home modules" and "[Home] Hide Home content feed" prepend the same call shape at the
         // same index. All three are pure List -> List filters on p1. Thus the patch that applies
         // last runs first, and the result is the same in every order.
         val homeState = mutableClassDefBy(HOME_STATE)

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidepremiumunsend/HidePremiumUnsendPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidepremiumunsend/HidePremiumUnsendPatch.kt
@@ -14,7 +14,7 @@ import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 
 @Suppress("unused")
 val hidePremiumUnsendPatch = bytecodePatch(
-    name = "Hide premium unsend upsells",
+    name = "[Premium] Hide premium unsend upsells",
     description = "Removes the LYP premium-unsend upsells that stay after \"Disable LINE " +
         "Premium\". These are the \"Unsend discreetly\" button, the post-unsend promo link, and " +
         "the expired-window unsend upsell. Ordinary unsend still works.",

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hideshoppingtab/HideShoppingTabPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hideshoppingtab/HideShoppingTabPatch.kt
@@ -6,7 +6,7 @@ import app.morphe.patcher.patch.bytecodePatch
 
 @Suppress("unused")
 val hideShoppingTabPatch = bytecodePatch(
-    name = "Hide Shopping tab",
+    name = "[Tab] Hide Shopping tab",
     description = "Removes the Shopping tab from the main bottom navigation. This includes the " +
         "Japan variant (Shopping, ショッピング) and the Taiwan variant (Discover, 逛逛).",
     default = true,

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidetransfer/HideTransferButtonPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidetransfer/HideTransferButtonPatch.kt
@@ -6,7 +6,7 @@ import app.morphe.patcher.patch.bytecodePatch
 
 @Suppress("unused")
 val hideTransferButtonPatch = bytecodePatch(
-    name = "Hide Transfer button",
+    name = "[Chat] Hide Transfer button",
     description = "Removes the Transfer (LINE Pay) tile from the + attach menu in a chat room.",
     default = true,
 ) {

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidevoomtab/HideVoomTabPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidevoomtab/HideVoomTabPatch.kt
@@ -6,7 +6,7 @@ import app.morphe.patcher.patch.bytecodePatch
 
 @Suppress("unused")
 val hideVoomTabPatch = bytecodePatch(
-    name = "Hide VOOM tab",
+    name = "[Tab] Hide VOOM tab",
     description = "Removes the VOOM (formerly Timeline) tab from the main bottom navigation.",
     default = true,
 ) {

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/hidewallettab/HideWalletTabPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/hidewallettab/HideWalletTabPatch.kt
@@ -6,7 +6,7 @@ import app.morphe.patcher.patch.bytecodePatch
 
 @Suppress("unused")
 val hideWalletTabPatch = bytecodePatch(
-    name = "Hide Wallet tab",
+    name = "[Tab] Hide Wallet tab",
     description = "Removes the Wallet (LINE Pay) tab from the main bottom navigation, " +
         "in both the normal and mini-tab layouts.",
     default = true,

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/keepunread/KeepChatsUnreadPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/keepunread/KeepChatsUnreadPatch.kt
@@ -6,7 +6,7 @@ import app.morphe.patcher.patch.bytecodePatch
 
 @Suppress("unused")
 val keepChatsUnreadPatch = bytecodePatch(
-    name = "Keep chats unread",
+    name = "[Chat] Keep chats unread",
     description = "When you open a 1:1 or group chat, LINE does not mark it read and sends no " +
         "read receipt. If you use \"Mark as read\" or \"Mark all as read\", LINE marks the chat " +
         "read and sends the receipt.",

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/keepunsent/KeepUnsentMessagesPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/keepunsent/KeepUnsentMessagesPatch.kt
@@ -22,7 +22,7 @@ private const val MAX_NIBBLE_REGISTER = 15
 
 @Suppress("unused")
 val keepUnsentMessagesPatch = bytecodePatch(
-    name = "Keep unsent messages",
+    name = "[Chat] Keep unsent messages",
     description = "Keeps unsent messages from 1:1 and group chats on your device instead of " +
         "erasing them. This patch shows the usual \"unsent a message\" notice directly below the " +
         "message that it kept. This patch does not apply to OpenChat.",

--- a/patches/src/main/kotlin/app/andrewliang/patches/line/removeads/RemoveBannerAdsPatch.kt
+++ b/patches/src/main/kotlin/app/andrewliang/patches/line/removeads/RemoveBannerAdsPatch.kt
@@ -11,7 +11,7 @@ private const val RETURN_NULL = """
 
 @Suppress("unused")
 val removeBannerAdsPatch = bytecodePatch(
-    name = "Remove banner ads",
+    name = "[Ad] Remove banner ads",
     description = "LINE no longer loads the Smart Channel banner ads. This patch makes the " +
         "getBanners and getPrefetchableBanners responses null.",
     default = true, // applied by default in Morphe Manager. Users can deselect it.


### PR DESCRIPTION
## What changes

Every patch name now starts with a category tag. The two patches that named GmsCore now name
MicroG-RE.

```
[Ad] Hide ad views                               <- Hide ad views
[Ad] Remove banner ads                           <- Remove banner ads
[Chat] Hide Events button                        <- Hide Events button
[Chat] Hide LINE GIFT button                     <- Hide LINE GIFT button
[Chat] Hide Transfer button                      <- Hide Transfer button
[Chat] Hide attach menu extra tools              <- Hide attach menu extra tools
[Chat] Hide calendar buttons                     <- Hide calendar buttons
[Chat] Hide community button                     <- Hide community button
[Chat] Keep chats unread                         <- Keep chats unread
[Chat] Keep unsent messages                      <- Keep unsent messages
[Fix] Restore chat backup sign-in via MicroG-RE  <- Fix chat backup sign-in via GmsCore  ** rename **
[Fix] Restore location maps via MicroG-RE        <- Fix location maps via GmsCore        ** rename **
[Fix] Restore push notifications                 <- Fix push notifications
[General] Disable VOOM                           <- Disable VOOM
[General] Hide new item badges                   <- Hide new item badges
[General] Open links in external browser         <- Open links in external browser
[General] Redirect LINE Pay                      <- Redirect LINE Pay
[Home] Hide Home content feed                    <- Hide Home content feed
[Home] Hide Home modules                         <- Hide Home modules
[Premium] Disable LINE Premium                   <- Disable LINE Premium
[Premium] Hide premium unsend upsells            <- Hide premium unsend upsells
[Tab] Hide LINE TODAY tab                        <- Hide LINE TODAY tab
[Tab] Hide Shopping tab                          <- Hide Shopping tab
[Tab] Hide VOOM tab                              <- Hide VOOM tab
[Tab] Hide Wallet tab                            <- Hide Wallet tab
```

The tags are singular: `Ad`, `Chat`, `Fix`, `General`, `Home`, `Premium`, `Tab`. The `[Fix]` group
reads "Restore ...", because the tag already says fix. "Restore" states what the patch gives back.

## Why a name prefix

The patcher has no category, group or tag field. A patch declares a name, a description, a default,
compatibility, dependencies and options, and nothing else. Both Morphe Manager and the generated
README table sort by name, so the prefix is the only lever that groups the list.

## Why the two renames

MicroG-RE is what both patches were built and tested against. The old names also contradicted their
own descriptions, which say the patch needs MicroG-RE.

For maps the old name was worse than inaccurate. Only MicroG-RE carries a Maps renderer, and only
from 7.0.0. A user who installed a different GmsCore build got nothing.

## Breaking change

Morphe Manager stores a selection by patch name. Its `SelectedPatch` primary key is
`["selection", "patch_name"]`. The Morphe CLI options file does the same: a
`Map<String, PatchEntry>`, keyed by `Patch.getName()`. Nothing maps an old name to a new one.

Every patch here is `default = true`. So **a patch that a user turned off comes back on**. The
Manager also reports each renamed patch as new. The `BREAKING CHANGE:` footer says this in the
release notes, and it tells users to check their selection first.

## Verification

Execution order was the risk worth a check. Morphe Manager applies patches sorted by name, so a
prefix reorders them. But every name in one category gains the same tag, so no category changes
internally. The patches that interact all sit inside one category — `[Home]` feed against modules,
and `[Premium]` premium against unsend upsells.

- A full default apply writes **1065 new classes**, the same count as before the rename. An
  exclusive apply of the maps patch writes 1003, also unchanged.
- A bracketed name works as a CLI selector:
  `--exclusive -e "[Fix] Restore location maps via MicroG-RE"` applies. This was the one new risk
  of the bracket format.
- `generatePatchesList` gives all 25 names, grouped and sorted, with no GmsCore left.
- The README generator makes `[[Ad] Hide ad views](#ad-hide-ad-views)`. The GitHub markdown API
  shows that the nested brackets resolve to `<a href="#ad-hide-ad-views">[Ad] Hide ad views</a>`,
  so the link text is correct.
- `patches-list.json` and the README table are **not** in this diff. The release regenerates both.

The diff is 34 files, with 95 insertions and 95 deletions. It changes:

- The 25 name strings
- One description that still said GmsCore
- The prose that names a patch, in `CLAUDE.md`, the reference docs, and the source comments
